### PR TITLE
feat: ProgressBar 공용 컴포넌트를 추가합니다.

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
     "./image-section": "./src/components/atom/image-section/index.tsx",
     "./flex": "./src/components/atom/flex/index.tsx",
     "./button": "./src/components/atom/button/index.tsx",
+    "./progress-bar": "./src/components/atom/progress-bar/index.tsx",
     "./renderComponents": "./src/components/renderComponents.tsx",
     "./types": "./src/types/server-driven.ts"
   },

--- a/packages/ui/src/components/atom/progress-bar/ProgressBar.stories.tsx
+++ b/packages/ui/src/components/atom/progress-bar/ProgressBar.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import ProgressBar from '.'
+
+const meta = {
+  title: 'Atom/ProgressBar',
+  component: ProgressBar,
+  parameters: {
+    layout: 'padded'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: { type: 'number', min: 0, max: 100 } },
+    showPercentage: {
+      control: 'boolean'
+    }
+  },
+  decorators: (Story) => (
+    <div className='px-40 py-10'>
+      <Story />
+    </div>
+  )
+} satisfies Meta<typeof ProgressBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ProgressBarWithoutPercentage: Story = {
+  args: {
+    value: 80,
+    showPercentage: false
+  }
+}
+
+export const ProgressBarWithPercentage: Story = {
+  args: {
+    value: 40,
+    showPercentage: true
+  }
+}

--- a/packages/ui/src/components/atom/progress-bar/example.json
+++ b/packages/ui/src/components/atom/progress-bar/example.json
@@ -1,0 +1,7 @@
+{
+  "type": "ProgressBar",
+  "props": {
+    "value": 80,
+    "showPercentage": true
+  }
+}

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -4,7 +4,12 @@ import Flex from '../flex'
 import { FlexAlign, FlexDirection } from '../flex/variants'
 import Typography from '../typography'
 import { TypographyColors, TypographyFontWeights, TypographyVariants } from '../typography/variants'
-import { ProgressBarValue, ProgressBarValueSchema } from './variants'
+import {
+  PROGRESS_BAR_VALUE_MAX_VALUE,
+  PROGRESS_BAR_VALUE_MIN_VALUE,
+  ProgressBarValue,
+  ProgressBarValueSchema
+} from './variants'
 
 type ProgressBarProps = ComponentProps<'div'> & {
   value: ProgressBarValue
@@ -20,12 +25,17 @@ function ProgressBar({
   className,
   ...props
 }: ProgressBarProps) {
-  const { success, data } = ProgressBarValueSchema.safeParse(value)
-  const validValue = success ? data : 0
+  const parseResult = ProgressBarValueSchema.safeParse(value)
 
-  if (!success) {
-    throw new Error('ProgressBar Value must be an between 0 and 100.')
+  if (!parseResult.success) {
+    const errorMessages = parseResult.error.issues.map((issue) => issue.message).join('; ')
+    throw new Error(`ProgressBar value error: ${errorMessages}`)
   }
+
+  const validValue = Math.min(
+    PROGRESS_BAR_VALUE_MAX_VALUE,
+    Math.max(PROGRESS_BAR_VALUE_MIN_VALUE, value)
+  )
 
   return (
     <Flex

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -15,7 +15,6 @@ type ProgressBarProps = ComponentProps<'div'> & {
   value: ProgressBarValue
   showPercentage?: boolean
   color?: string
-  asChild?: boolean
 }
 
 function ProgressBar({

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -27,6 +27,10 @@ function ProgressBar({
   const { success, data } = ProgressBarValueSchema.safeParse(value)
   const validValue = success ? data : 0
 
+  if (!success) {
+    throw new Error('ProgressBar Value must be an between 0 and 100.')
+  }
+
   return (
     <Flex
       direction={FlexDirection.COLUMN}

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -1,0 +1,67 @@
+import { Slot } from '@radix-ui/react-slot'
+import { ComponentProps } from 'react'
+
+import Flex from '../flex'
+import { FlexAlign, FlexDirection } from '../flex/variants'
+import Typography from '../typography'
+import { TypographyColors, TypographyFontWeights, TypographyVariants } from '../typography/variants'
+
+type ProgressBarProps = ComponentProps<'div'> & {
+  value: number
+  showPercentage?: boolean
+  color?: string
+  asChild?: boolean
+}
+
+function ProgressBar({
+  value = 0,
+  showPercentage = true,
+  color = 'primary-normal',
+  asChild,
+  className,
+  ...props
+}: ProgressBarProps) {
+  const Component = asChild ? Slot : 'div'
+
+  if (value === undefined) {
+    throw new Error('value is required')
+  }
+
+  return (
+    <Flex
+      direction={FlexDirection.COLUMN}
+      align={FlexAlign.END}
+      className={`w-[100%] gap-[0.25rem] ${className}`}
+      {...props}>
+      <PercentageText
+        value={value}
+        showPercentage={showPercentage}
+      />
+      <Component className='relative min-h-[0.375rem] w-[100%] rounded-[1.875rem] bg-[#17171715]'>
+        <div
+          className={`absolute right-0 top-0 min-h-[0.375rem] rounded-[1.875rem] bg-${color}`}
+          style={{ width: `${value}%` }}
+        />
+      </Component>
+    </Flex>
+  )
+}
+
+type PercentageTextProps = {
+  value: number
+  showPercentage?: boolean
+}
+
+function PercentageText({ value, showPercentage = true }: PercentageTextProps) {
+  if (!showPercentage) return null
+  return (
+    <Typography
+      variant={TypographyVariants.CAPTION2}
+      fontWeight={TypographyFontWeights.REGULAR}
+      color={TypographyColors.ALTERNATIVE}>
+      {value}%
+    </Typography>
+  )
+}
+
+export default ProgressBar

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -1,4 +1,3 @@
-import { Slot } from '@radix-ui/react-slot'
 import { ComponentProps } from 'react'
 
 import Flex from '../flex'
@@ -18,12 +17,9 @@ function ProgressBar({
   value,
   showPercentage = true,
   color = 'primary-normal',
-  asChild,
   className,
   ...props
 }: ProgressBarProps) {
-  const Component = asChild ? Slot : 'div'
-
   const { success, data } = ProgressBarValueSchema.safeParse(value)
   const validValue = success ? data : 0
 
@@ -37,34 +33,21 @@ function ProgressBar({
       align={FlexAlign.END}
       className={`w-[100%] gap-[0.25rem] ${className}`}
       {...props}>
-      <PercentageText
-        value={validValue}
-        showPercentage={showPercentage}
-      />
-      <Component className='relative min-h-[0.375rem] w-[100%] rounded-[1.875rem] bg-[#17171715]'>
+      {showPercentage && (
+        <Typography
+          variant={TypographyVariants.CAPTION2}
+          fontWeight={TypographyFontWeights.REGULAR}
+          color={TypographyColors.ALTERNATIVE}>
+          {validValue}%
+        </Typography>
+      )}
+      <div className='relative min-h-[0.375rem] w-[100%] rounded-[1.875rem] bg-[#17171715]'>
         <div
           className={`absolute right-0 top-0 min-h-[0.375rem] rounded-[1.875rem] bg-${color}`}
           style={{ width: `${validValue}%` }}
         />
-      </Component>
+      </div>
     </Flex>
-  )
-}
-
-type PercentageTextProps = {
-  value: number
-  showPercentage?: boolean
-}
-
-function PercentageText({ value, showPercentage = true }: PercentageTextProps) {
-  if (!showPercentage) return null
-  return (
-    <Typography
-      variant={TypographyVariants.CAPTION2}
-      fontWeight={TypographyFontWeights.REGULAR}
-      color={TypographyColors.ALTERNATIVE}>
-      {value}%
-    </Typography>
   )
 }
 

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -5,16 +5,17 @@ import Flex from '../flex'
 import { FlexAlign, FlexDirection } from '../flex/variants'
 import Typography from '../typography'
 import { TypographyColors, TypographyFontWeights, TypographyVariants } from '../typography/variants'
+import { ProgressBarValue, ProgressBarValueSchema } from './variants'
 
 type ProgressBarProps = ComponentProps<'div'> & {
-  value: number
+  value: ProgressBarValue
   showPercentage?: boolean
   color?: string
   asChild?: boolean
 }
 
 function ProgressBar({
-  value = 0,
+  value,
   showPercentage = true,
   color = 'primary-normal',
   asChild,
@@ -23,9 +24,8 @@ function ProgressBar({
 }: ProgressBarProps) {
   const Component = asChild ? Slot : 'div'
 
-  if (value === undefined) {
-    throw new Error('value is required')
-  }
+  const { success, data } = ProgressBarValueSchema.safeParse(value)
+  const validValue = success ? data : 0
 
   return (
     <Flex
@@ -34,13 +34,13 @@ function ProgressBar({
       className={`w-[100%] gap-[0.25rem] ${className}`}
       {...props}>
       <PercentageText
-        value={value}
+        value={validValue}
         showPercentage={showPercentage}
       />
       <Component className='relative min-h-[0.375rem] w-[100%] rounded-[1.875rem] bg-[#17171715]'>
         <div
           className={`absolute right-0 top-0 min-h-[0.375rem] rounded-[1.875rem] bg-${color}`}
-          style={{ width: `${value}%` }}
+          style={{ width: `${validValue}%` }}
         />
       </Component>
     </Flex>

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -43,8 +43,12 @@ function ProgressBar({
       )}
       <div className='relative min-h-[0.375rem] w-[100%] rounded-[1.875rem] bg-[#17171715]'>
         <div
-          className={`absolute right-0 top-0 min-h-[0.375rem] rounded-[1.875rem] bg-${color}`}
-          style={{ width: `${validValue}%` }}
+          className={`absolute right-0 top-0 min-h-[0.375rem] w-[100%] rounded-[1.875rem] bg-${color}`}
+          style={{
+            transform: `scaleX(${validValue / 100})`,
+            transformOrigin: 'center right',
+            transition: 'transform 1.5s ease'
+          }}
         />
       </div>
     </Flex>

--- a/packages/ui/src/components/atom/progress-bar/variants.ts
+++ b/packages/ui/src/components/atom/progress-bar/variants.ts
@@ -4,7 +4,6 @@ export const PROGRESS_BAR_VALUE_MIN_VALUE = 0
 export const PROGRESS_BAR_VALUE_MAX_VALUE = 100
 export const ProgressBarValueSchema = z
   .number()
-  .int()
   .min(PROGRESS_BAR_VALUE_MIN_VALUE)
   .max(PROGRESS_BAR_VALUE_MAX_VALUE)
 

--- a/packages/ui/src/components/atom/progress-bar/variants.ts
+++ b/packages/ui/src/components/atom/progress-bar/variants.ts
@@ -2,9 +2,26 @@ import { z } from 'zod'
 
 export const PROGRESS_BAR_VALUE_MIN_VALUE = 0
 export const PROGRESS_BAR_VALUE_MAX_VALUE = 100
-export const ProgressBarValueSchema = z
-  .number()
-  .min(PROGRESS_BAR_VALUE_MIN_VALUE)
-  .max(PROGRESS_BAR_VALUE_MAX_VALUE)
+
+export const ProgressBarValueSchema = z.number().superRefine((value, ctx) => {
+  if (value < PROGRESS_BAR_VALUE_MIN_VALUE) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_small,
+      minimum: PROGRESS_BAR_VALUE_MIN_VALUE,
+      type: 'number',
+      inclusive: true,
+      message: `Value is too low. Minimum value allowed is ${PROGRESS_BAR_VALUE_MIN_VALUE}.`
+    })
+  }
+  if (value > PROGRESS_BAR_VALUE_MAX_VALUE) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_big,
+      maximum: PROGRESS_BAR_VALUE_MAX_VALUE,
+      type: 'number',
+      inclusive: true,
+      message: `Value is too high. Maximum value allowed is ${PROGRESS_BAR_VALUE_MAX_VALUE}.`
+    })
+  }
+})
 
 export type ProgressBarValue = z.infer<typeof ProgressBarValueSchema>

--- a/packages/ui/src/components/atom/progress-bar/variants.ts
+++ b/packages/ui/src/components/atom/progress-bar/variants.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const PROGRESS_BAR_VALUE_MIN_VALUE = 0
+export const PROGRESS_BAR_VALUE_MAX_VALUE = 100
+export const ProgressBarValueSchema = z
+  .number()
+  .int()
+  .min(PROGRESS_BAR_VALUE_MIN_VALUE)
+  .max(PROGRESS_BAR_VALUE_MAX_VALUE)
+
+export type ProgressBarValue = z.infer<typeof ProgressBarValueSchema>

--- a/packages/ui/src/components/renderComponents.tsx
+++ b/packages/ui/src/components/renderComponents.tsx
@@ -3,6 +3,7 @@ import type { ServerDrivenComponentType } from '@/types/server-driven'
 import { OutlinedButton, SolidButton, TextButton } from './atom/button'
 import Flex from './atom/flex'
 import ImageSection from './atom/image-section'
+import ProgressBar from './atom/progress-bar'
 import RadioGroup from './atom/radio-group'
 import SpacingBlock from './atom/spacing-block'
 import Typography from './atom/typography'
@@ -43,6 +44,9 @@ export function renderComponents(componentData: ServerDrivenComponentType) {
 
     case 'Flex':
       return <Flex {...props}>{children?.map((child) => renderComponents(child))}</Flex>
+
+    case 'ProgressBar':
+      return <ProgressBar {...props} />
 
     default:
       console.warn(`Unknown component type: ${type}`)

--- a/packages/ui/src/types/server-driven.ts
+++ b/packages/ui/src/types/server-driven.ts
@@ -3,6 +3,7 @@ import { ComponentProps } from 'react'
 import { OutlinedButton, SolidButton, TextButton } from '@/components/atom/button'
 import Flex from '@/components/atom/flex'
 import ImageSection from '@/components/atom/image-section'
+import ProgressBar from '@/components/atom/progress-bar'
 import RadioGroup from '@/components/atom/radio-group'
 import SpacingBlock from '@/components/atom/spacing-block'
 import Typography from '@/components/atom/typography'
@@ -17,6 +18,7 @@ export type ComponentPropsMap = {
   OutlinedButton: ComponentProps<typeof OutlinedButton>
   TextButton: ComponentProps<typeof TextButton>
   Flex: ComponentProps<typeof Flex>
+  ProgressBar: ComponentProps<typeof ProgressBar>
 }
 
 export type ServerDrivenComponentType =
@@ -33,3 +35,4 @@ export type ServerDrivenComponentType =
   | { type: 'OutlinedButton'; props: ComponentPropsMap['OutlinedButton']; children?: never }
   | { type: 'TextButton'; props: ComponentPropsMap['TextButton']; children?: never }
   | { type: 'Flex'; props: ComponentPropsMap['Flex']; children?: ServerDrivenComponentType[] }
+  | { type: 'ProgressBar'; props: ComponentPropsMap['ProgressBar']; children?: never }


### PR DESCRIPTION
## 🌱 작업 개요

- ProgressBar 공용 컴포넌트를 추가합니다.

## 🧐 중요한 변경 사항

<img width="538" alt="image" src="https://github.com/user-attachments/assets/73a848d1-997e-4900-b8a2-c9bbd17093eb">

- 컴포넌트의 value 값을 0~100까지의 퍼센트로 표현 가능한 범위로 zod를 사용해 타입 안정성을 높였습니다.
- showPercentage가 true일 경우, 진행 퍼센트를 표시하는 텍스트는 Typography 컴포넌트를 사용해 스타일을 적용했습니다.

## 👻 질문 사항

- 현재 color 속성을 통해 포인트 색상만 수정할 수 있습니다. 확장성을 고려하여 backgroundColor와 pointColor 모두 수정할 수 있도록 하는 것이 좋을까요?

