### PR TITLE
refactor: storybook에서 절대경로를 읽기위해 설정을 변경합니다.

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -33,7 +33,8 @@ const config: StorybookConfig = {
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
-        '@': resolve(__dirname, '../src')
+        '@': resolve(__dirname, '../src'),
+        '@ui': resolve(__dirname, '../../../packages/ui/src')
       }
     }
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@ui/*": ["../../../packages/ui/src/*"],
+      "@ui/*": ["../../packages/ui/src/*"],
       "@config/es-config/*": ["../../config/es-config/*"],
       "@config/ts-config/*": ["../../config/ts-config/*"]
     },
@@ -14,6 +14,12 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "next.config.mjs", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "next.config.mjs",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
+      "@ui/*": ["../../../packages/ui/src/*"],
       "@config/es-config/*": ["../../config/es-config/*"],
       "@config/ts-config/*": ["../../config/ts-config/*"]
     },

--- a/packages/ui/src/components/atom/badge/Badge.stories.tsx
+++ b/packages/ui/src/components/atom/badge/Badge.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import Badge from '.'
-import { BadgeColors, BadgeSizes } from './variants'
+import Badge from '@ui/components/atom/badge'
+import { BadgeColors, BadgeSizes } from '@ui/components/atom/badge/variants'
 
 const meta = {
   title: 'Atom/Badge',

--- a/packages/ui/src/components/atom/badge/index.tsx
+++ b/packages/ui/src/components/atom/badge/index.tsx
@@ -1,8 +1,7 @@
 import { Slot } from '@radix-ui/react-slot'
+import { BadgeColors, BadgeSizes } from '@ui/components/atom/badge/variants'
 import { cva, VariantProps } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, ElementType } from 'react'
-
-import { BadgeColors, BadgeSizes } from './variants'
 
 export const badgeVariants = cva(
   'rounded-[0.25rem] inline-flex font-medium flex items-center justify-center',

--- a/packages/ui/src/components/atom/button/OutlinedButton.tsx
+++ b/packages/ui/src/components/atom/button/OutlinedButton.tsx
@@ -1,9 +1,13 @@
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@repo/util'
+import {
+  ButtonSize,
+  ButtonVariant,
+  CustomButtonProps,
+  SizeMapping
+} from '@ui/components/atom/button/variants'
+import Typography from '@ui/components/atom/typography'
 import { cva, type VariantProps } from 'class-variance-authority'
-
-import Typography from '../typography'
-import { ButtonSize, ButtonVariant, CustomButtonProps, SizeMapping } from './variants'
 
 const buttonVariants = cva(
   'reset-button rounded-lg px-[1rem] bg-inherit flex items-center justify-center gap-[0.25rem] border-[1.5px] border-solid',

--- a/packages/ui/src/components/atom/button/SolidButton.stories.tsx
+++ b/packages/ui/src/components/atom/button/SolidButton.stories.tsx
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import SolidButton from '@ui/components/atom/button/SolidButton'
+import { ButtonSize, ButtonVariant } from '@ui/components/atom/button/variants'
+import Icon from '@ui/components/atom/icon'
 import { useState } from 'react'
-
-import Icon from '../icon'
-import SolidButton from './SolidButton'
-import { ButtonSize, ButtonVariant } from './variants'
 
 const meta = {
   title: 'Atom/Button/SolidButton',

--- a/packages/ui/src/components/atom/button/SolidButton.tsx
+++ b/packages/ui/src/components/atom/button/SolidButton.tsx
@@ -1,9 +1,13 @@
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@repo/util'
+import {
+  ButtonSize,
+  ButtonVariant,
+  CustomButtonProps,
+  SizeMapping
+} from '@ui/components/atom/button/variants'
+import Typography from '@ui/components/atom/typography'
 import { cva, type VariantProps } from 'class-variance-authority'
-
-import Typography from '../typography'
-import { ButtonSize, ButtonVariant, CustomButtonProps, SizeMapping } from './variants'
 
 const buttonVariants = cva(
   'reset-button rounded-lg px-[1rem] flex items-center justify-center gap-[0.25rem]',

--- a/packages/ui/src/components/atom/button/TextButton.stories.tsx
+++ b/packages/ui/src/components/atom/button/TextButton.stories.tsx
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import TextButton from '@ui/components/atom/button/TextButton'
+import { ButtonSize, ButtonVariant } from '@ui/components/atom/button/variants'
+import Icon from '@ui/components/atom/icon'
 import { useState } from 'react'
-
-import Icon from '../icon'
-import SolidButton from './TextButton'
-import TextButton from './TextButton'
-import { ButtonSize, ButtonVariant } from './variants'
 
 const meta = {
   title: 'Atom/Button/TextButton',
@@ -26,7 +24,7 @@ const meta = {
       control: 'boolean'
     }
   }
-} satisfies Meta<typeof SolidButton>
+} satisfies Meta<typeof TextButton>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -64,7 +62,7 @@ export const WithIcon: Story = {
   render: (args) => {
     const [disabled, setDisabled] = useState(false)
     return (
-      <SolidButton
+      <TextButton
         onClick={() => setDisabled((prev) => !prev)}
         {...args}
         rightIcon={<Icon name='RightOutlined' />}

--- a/packages/ui/src/components/atom/button/TextButton.tsx
+++ b/packages/ui/src/components/atom/button/TextButton.tsx
@@ -1,9 +1,13 @@
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@repo/util'
+import {
+  ButtonSize,
+  ButtonVariant,
+  CustomButtonProps,
+  SizeMapping
+} from '@ui/components/atom/button/variants'
+import Typography from '@ui/components/atom/typography'
 import { cva, type VariantProps } from 'class-variance-authority'
-
-import Typography from '../typography'
-import { ButtonSize, ButtonVariant, CustomButtonProps, SizeMapping } from './variants'
 
 const buttonVariants = cva('reset-button flex items-center justify-center gap-[0.25rem]', {
   variants: {

--- a/packages/ui/src/components/atom/button/index.tsx
+++ b/packages/ui/src/components/atom/button/index.tsx
@@ -1,3 +1,3 @@
-export { default as OutlinedButton } from './OutlinedButton'
-export { default as SolidButton } from './SolidButton'
-export { default as TextButton } from './TextButton'
+export { default as OutlinedButton } from '@ui/components/atom/button/OutlinedButton'
+export { default as SolidButton } from '@ui/components/atom/button/SolidButton'
+export { default as TextButton } from '@ui/components/atom/button/TextButton'

--- a/packages/ui/src/components/atom/button/variants.ts
+++ b/packages/ui/src/components/atom/button/variants.ts
@@ -1,6 +1,5 @@
+import Typography from '@ui/components/atom/typography'
 import { ComponentProps, ComponentPropsWithoutRef } from 'react'
-
-import Typography from '../typography'
 
 export type CustomButtonProps = ComponentPropsWithoutRef<'button'> & {
   asChild?: boolean

--- a/packages/ui/src/components/atom/flex/Flex.stories.tsx
+++ b/packages/ui/src/components/atom/flex/Flex.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import SpacingBlock from '../spacing-block'
-import Flex from '.'
-import { FlexAlign, FlexDirection, FlexGap, FlexJustify, FlexWrap } from './variants'
+import Flex from '@ui/components/atom/flex'
+import {
+  FlexAlign,
+  FlexDirection,
+  FlexGap,
+  FlexJustify,
+  FlexWrap
+} from '@ui/components/atom/flex/variants'
+import SpacingBlock from '@ui/components/atom/spacing-block'
 
 const meta = {
   title: 'Atom/Flex',

--- a/packages/ui/src/components/atom/flex/index.tsx
+++ b/packages/ui/src/components/atom/flex/index.tsx
@@ -1,9 +1,14 @@
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@repo/util'
+import {
+  FlexAlign,
+  FlexDirection,
+  FlexGap,
+  FlexJustify,
+  FlexWrap
+} from '@ui/components/atom/flex/variants'
 import { cva, VariantProps } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, ElementType } from 'react'
-
-import { FlexAlign, FlexDirection, FlexGap, FlexJustify, FlexWrap } from './variants'
 
 const flexVariants = cva('flex', {
   variants: {

--- a/packages/ui/src/components/atom/icon/index.tsx
+++ b/packages/ui/src/components/atom/icon/index.tsx
@@ -1,7 +1,6 @@
+import { IconsMap, IconsSizes, IconVariantType } from '@ui/components/atom/icon/variants'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { ComponentPropsWithoutRef } from 'react'
-
-import { IconsMap, IconsSizes, IconVariantType } from './variants'
 
 type Props = {
   name: IconVariantType

--- a/packages/ui/src/components/atom/image-section/ImageSection.stories.tsx
+++ b/packages/ui/src/components/atom/image-section/ImageSection.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import ImageSection from '.'
-import { ImageFits, ImageSizes } from './variants'
+import ImageSection from '@ui/components/atom/image-section'
+import { ImageFits, ImageSizes } from '@ui/components/atom/image-section/variants'
 
 const meta: Meta<typeof ImageSection> = {
   title: 'Atom/ImageSection',

--- a/packages/ui/src/components/atom/image-section/index.tsx
+++ b/packages/ui/src/components/atom/image-section/index.tsx
@@ -1,8 +1,7 @@
+import { ImageFits, ImageSizes } from '@ui/components/atom/image-section/variants'
 import { cva, VariantProps } from 'class-variance-authority'
 import Image from 'next/image'
 import { ComponentPropsWithoutRef, ElementType } from 'react'
-
-import { ImageFits, ImageSizes } from './variants'
 
 export const imageSectionVariants = cva('', {
   variants: {

--- a/packages/ui/src/components/atom/progress-bar/ProgressBar.stories.tsx
+++ b/packages/ui/src/components/atom/progress-bar/ProgressBar.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import ProgressBar from '.'
+import ProgressBar from '@ui/components/atom/progress-bar'
 
 const meta = {
   title: 'Atom/ProgressBar',

--- a/packages/ui/src/components/atom/progress-bar/index.tsx
+++ b/packages/ui/src/components/atom/progress-bar/index.tsx
@@ -1,15 +1,19 @@
-import { ComponentProps } from 'react'
-
-import Flex from '../flex'
-import { FlexAlign, FlexDirection } from '../flex/variants'
-import Typography from '../typography'
-import { TypographyColors, TypographyFontWeights, TypographyVariants } from '../typography/variants'
+import { FlexAlign, FlexDirection } from '@ui/components/atom/flex/variants'
 import {
   PROGRESS_BAR_VALUE_MAX_VALUE,
   PROGRESS_BAR_VALUE_MIN_VALUE,
   ProgressBarValue,
   ProgressBarValueSchema
-} from './variants'
+} from '@ui/components/atom/progress-bar/variants'
+import Typography from '@ui/components/atom/typography'
+import {
+  TypographyColors,
+  TypographyFontWeights,
+  TypographyVariants
+} from '@ui/components/atom/typography/variants'
+import { ComponentProps } from 'react'
+
+import Flex from '../flex'
 
 type ProgressBarProps = ComponentProps<'div'> & {
   value: ProgressBarValue

--- a/packages/ui/src/components/atom/radio-group/RadioGroup.stories.tsx
+++ b/packages/ui/src/components/atom/radio-group/RadioGroup.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import RadioGroup from '.'
+import RadioGroup from '@ui/components/atom/radio-group'
 
 const meta = {
   title: 'Atom/RadioGroup',

--- a/packages/ui/src/components/atom/spacing-block/SpacingBlock.stories.tsx
+++ b/packages/ui/src/components/atom/spacing-block/SpacingBlock.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import Typography from '../typography'
-import SpacingBlock from '.'
-import { SpacingBlockVariants } from './variants'
+import SpacingBlock from '@ui/components/atom/spacing-block'
+import { SpacingBlockVariants } from '@ui/components/atom/spacing-block/variants'
+import Typography from '@ui/components/atom/typography'
 
 const meta = {
   title: 'Atom/SpacingBlock',
@@ -60,7 +59,7 @@ export const AsChild: Story = {
   },
   render: (args) => (
     <SpacingBlock {...args}>
-      <Typography variant='caption-1'>Spacing</Typography>
+      <Typography variant='body-1-normal'>Spacing</Typography>
     </SpacingBlock>
   )
 }

--- a/packages/ui/src/components/atom/spacing-block/index.tsx
+++ b/packages/ui/src/components/atom/spacing-block/index.tsx
@@ -1,9 +1,8 @@
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@repo/util'
+import { SpacingBlockVariants } from '@ui/components/atom/spacing-block/variants'
 import { cva, VariantProps } from 'class-variance-authority'
 import { ComponentProps } from 'react'
-
-import { SpacingBlockVariants } from './variants'
 
 const spacingBlockVariants = cva('', {
   variants: {

--- a/packages/ui/src/components/atom/typography/Typogrpahy.stories.ts
+++ b/packages/ui/src/components/atom/typography/Typogrpahy.stories.ts
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import Typography from '.'
-import { TypographyColors, TypographyFontWeights, TypographyVariants } from './variants'
+import Typography from '@ui/components/atom/typography'
+import {
+  TypographyColors,
+  TypographyFontWeights,
+  TypographyVariants
+} from '@ui/components/atom/typography/variants'
 
 const meta = {
   title: 'Atom/Typography',

--- a/packages/ui/src/components/atom/typography/index.tsx
+++ b/packages/ui/src/components/atom/typography/index.tsx
@@ -1,8 +1,11 @@
 import { Slot } from '@radix-ui/react-slot'
-import { cva, VariantProps } from 'class-variance-authority'
+import {
+  TypographyColors,
+  TypographyFontWeights,
+  TypographyVariants
+} from '@ui/components/atom/typography/variants'
+import { cva } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, ElementType } from 'react'
-
-import { TypographyColors, TypographyFontWeights, TypographyVariants } from './variants'
 
 export const typographyVariants = cva('', {
   variants: {
@@ -46,11 +49,14 @@ export const typographyVariants = cva('', {
   }
 })
 
-type TypographyProps = VariantProps<typeof typographyVariants> &
-  ComponentPropsWithoutRef<'span'> & {
-    component?: ElementType
-    asChild?: boolean
-  }
+type TypographyProps = ComponentPropsWithoutRef<'span'> & {
+  component?: ElementType
+  asChild?: boolean
+} & {
+  variant?: (typeof TypographyVariants)[keyof typeof TypographyVariants]
+  fontWeight?: (typeof TypographyFontWeights)[keyof typeof TypographyFontWeights]
+  color?: (typeof TypographyColors)[keyof typeof TypographyColors]
+}
 
 function Typography({
   component = 'span',

--- a/packages/ui/src/components/molecule/path-product-item/PathProductItemBasic.stories.tsx
+++ b/packages/ui/src/components/molecule/path-product-item/PathProductItemBasic.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
-import PathProductItemBasic from './PathProductItemBasic'
+import PathProductItemBasic from '@ui/components/molecule/path-product-item/PathProductItemBasic'
 
 const meta = {
   title: 'Molecule/PathProductItem/PathProductItemBasic',

--- a/packages/ui/src/components/molecule/path-product-item/PathProductItemBasic.tsx
+++ b/packages/ui/src/components/molecule/path-product-item/PathProductItemBasic.tsx
@@ -1,10 +1,12 @@
 import { Slot } from '@radix-ui/react-slot'
+import Badge from '@ui/components/atom/badge'
+import ImageSection from '@ui/components/atom/image-section'
+import Typography from '@ui/components/atom/typography'
+import {
+  PATH_STATUS_BADGE,
+  PathStatusBadgeType
+} from '@ui/components/molecule/path-product-item/variants'
 import { ComponentProps, ElementType } from 'react'
-
-import Badge from '../../atom/badge'
-import ImageSection from '../../atom/image-section'
-import Typography from '../../atom/typography'
-import { PATH_STATUS_BADGE, PathStatusBadgeType } from './variants'
 
 type PathProductItemBasicProps = ComponentProps<'div'> & {
   component?: ElementType

--- a/packages/ui/src/components/molecule/path-product-item/variants.ts
+++ b/packages/ui/src/components/molecule/path-product-item/variants.ts
@@ -1,4 +1,4 @@
-import { BadgeColors } from '../../atom/badge/variants'
+import { BadgeColors } from '@ui/components/atom/badge/variants'
 
 export const PATH_STATUS_BADGE = {
   SCHEDULE: {

--- a/packages/ui/src/components/renderComponents.tsx
+++ b/packages/ui/src/components/renderComponents.tsx
@@ -1,7 +1,7 @@
-import type { ServerDrivenComponentType } from '@/types/server-driven'
+import Badge from '@ui/components/atom/badge'
+import { OutlinedButton, SolidButton, TextButton } from '@ui/components/atom/button'
+import type { ServerDrivenComponentType } from '@ui/types/server-driven'
 
-import Badge from './atom/badge'
-import { OutlinedButton, SolidButton, TextButton } from './atom/button'
 import Flex from './atom/flex'
 import Icon from './atom/icon'
 import ImageSection from './atom/image-section'

--- a/packages/ui/src/types/server-driven.ts
+++ b/packages/ui/src/types/server-driven.ts
@@ -1,14 +1,13 @@
+import Badge from '@ui/components/atom/badge'
+import { OutlinedButton, SolidButton, TextButton } from '@ui/components/atom/button'
+import Flex from '@ui/components/atom/flex'
+import Icon from '@ui/components/atom/icon'
+import ImageSection from '@ui/components/atom/image-section'
+import ProgressBar from '@ui/components/atom/progress-bar'
+import RadioGroup from '@ui/components/atom/radio-group'
+import SpacingBlock from '@ui/components/atom/spacing-block'
+import Typography from '@ui/components/atom/typography'
 import { ComponentProps } from 'react'
-
-import Badge from '@/components/atom/badge'
-import { OutlinedButton, SolidButton, TextButton } from '@/components/atom/button'
-import Flex from '@/components/atom/flex'
-import Icon from '@/components/atom/icon'
-import ImageSection from '@/components/atom/image-section'
-import ProgressBar from '@/components/atom/progress-bar'
-import RadioGroup from '@/components/atom/radio-group'
-import SpacingBlock from '@/components/atom/spacing-block'
-import Typography from '@/components/atom/typography'
 
 export type ComponentPropsMap = {
   RadioGroup: ComponentProps<typeof RadioGroup>

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
+      "@ui/*": ["./src/*"],
       "@config/es-config/*": ["../../config/es-config/*"],
       "@config/ts-config/*": ["../../config/ts-config/*"]
     },

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': resolve(__dirname, './src')
+      '@repo/ui': resolve(__dirname, './src')
     }
   },
   build: {


### PR DESCRIPTION
## 🌱 작업 개요

<!--작업하신 내용을 간단하게 목록 형식으로 설명해주세요.-->
- [storybook에서 절대경로를 읽기위해 설정을 변경합니다.](https://github.com/mobi-production/ani-fe/commit/3f36acfce038bb31e478a35d5817f7751d088477)

## 🧐 중요한 변경 사항

### 상대경로가 아닌 절대경로로도 접근이 가능합니다.

[언급했던 방법](https://github.com/mobi-production/ani-fe/pull/19#issuecomment-2468232730)을 통해 수정하였습니다.

> @repo/ui 내 tsconfig부터 vite.config까지 모든 path alias 설정부터 기존 apps/web 내 storybook 설정까지 변경하려고 합니다. 해당 부분 번거로울 수 있으니 제가 한번 진행해 보겠습니다!

기존에 ...으로 접근하던 방식에서 `@ui/...`로 접근할 수 있습니다.

변경전

```tsx
import Typography from '../typography'
import { ButtonSize, ButtonVariant, CustomButtonProps, SizeMapping } from './variants'
```

변경후

```tsx
import {
  ButtonSize,
  ButtonVariant,
  CustomButtonProps,
  SizeMapping
} from '@ui/components/atom/button/variants'
import Typography from '@ui/components/atom/typography'
```

<!--스크린샷이 있다면 추가해주세요.-->
<!--공용 컴포넌트, 린트 설정 등에 변경이 있다면 꼭 공유해주세요.-->

현재 있는 문제점이 `VariantProps` 를 읽지# 🌱 작업 개요

<!--작업하신 내용을 간단하게 목록 형식으로 설명해주세요.-->
- [storybook에서 절대경로를 읽기위해 설정을 변경합니다.](https://github.com/mobi-production/ani-fe/commit/3f36acfce038bb31e478a35d5817f7751d088477)

## 🧐 중요한 변경 사항

### 상대경로가 아닌 절대경로로도 접근이 가능합니다.

[언급했던 방법](https://github.com/mobi-production/ani-fe/pull/19#issuecomment-2468232730)을 통해 수정하였습니다.

> @repo/ui 내 tsconfig부터 vite.config까지 모든 path alias 설정부터 기존 apps/web 내 storybook 설정까지 변경하려고 합니다. 해당 부분 번거로울 수 있으니 제가 한번 진행해 보겠습니다!

기존에 ...으로 접근하던 방식에서 `@ui/...`로 접근할 수 있습니다.

변경전

```tsx
import Typography from '../typography'
import { ButtonSize, ButtonVariant, CustomButtonProps, SizeMapping } from './variants'
```

변경후

```tsx
import {
  ButtonSize,
  ButtonVariant,
  CustomButtonProps,
  SizeMapping
} from '@ui/components/atom/button/variants'
import Typography from '@ui/components/atom/typography'
```

<!--스크린샷이 있다면 추가해주세요.-->
<!--공용 컴포넌트, 린트 설정 등에 변경이 있다면 꼭 공유해주세요.-->

현재 생겨난 이슈가 있습니다.

`VariantProps` 를 읽지 못해 따로 타입을 명시를 해주고 있습니다.

```tsx
type TypographyProps = ComponentPropsWithoutRef<'span'> & {
  component?: ElementType
  asChild?: boolean
} & {
  variant?: (typeof TypographyVariants)[keyof typeof TypographyVariants]
  fontWeight?: (typeof TypographyFontWeights)[keyof typeof TypographyFontWeights]
  color?: (typeof TypographyColors)[keyof typeof TypographyColors]
}
```

## 👻 질문 사항

1. 현재 컴포넌트들을 client 환경에서 사용하는 (예: use... 훅을 사용하는 컴포넌트들)과 static 상태의 컴포넌트로 구분하여 배럴 파일로 내보내려고 합니다. 파일이 너무 길어지는 문제를 방지하고자 하는데, 이에 대해 어떻게 생각하시는지 의견 부탁드립니다.

2. atom과 molecule이 모두 작성되어 있는데, 공통적인 atom 단위만 작성하는 것이 좋을 것 같습니다. atom 폴더를 제거하고 가장 작은 단위의 컴포넌트만 개별 파일로 풀어쓰는 방향을 고려하고 있습니다. 이에 대해 의견 부탁드립니다. 또한, PathProductItemBasic은 apps/web으로 이동하면 될 것 같습니다.

<!--함께 고민하고 싶은 것이 있다면 작성해주세요.-->
<!--중점적으로 피드백 받고 싶은 부분을 작성해주세요.-->
