### PR TITLE
feat : PathProductAssignment 공용 컴포넌트를 추가합니다.

### DIFF
--- a/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.stories.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
     layout: 'centered',
     docs: {
       description: {
-        component: '패스 컨텐츠를 보여줄 수 있는 Item 컴포넌트 입니다.'
+        component: '패스의 과제 컨텐츠를 보여줄 수 있는 Item 컴포넌트 입니다.'
       }
     }
   },

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.stories.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import PathProductItemAssignment from './PathProductItemAssignment'
+
+const meta = {
+  title: 'ProductItem/Assignment',
+  component: PathProductItemAssignment,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '패스 컨텐츠를 보여줄 수 있는 Item 컴포넌트 입니다.'
+      }
+    }
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof PathProductItemAssignment>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  render: (args) => (
+    <PathProductItemAssignment {...args}>
+      <PathProductItemAssignment.LeftSection
+        src='/avif/placeholder.avif'
+        alt='placeholder image'
+        pathName='HTML & CSS'
+        assignmentName='과제 이름 1줄까지 과제 이름 1줄까지'
+        endDate='~ 2024.10.06'
+      />
+      <PathProductItemAssignment.StatusBadge badgeType='SUBMITTED' />
+    </PathProductItemAssignment>
+  )
+}

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.tsx
@@ -1,20 +1,15 @@
-import { Badge, ImageSection, Typography } from '@repo/ui/server'
-import { ComponentProps, ElementType, useMemo } from 'react'
+import { Badge, Flex, ImageSection, Typography } from '@repo/ui/server'
+import { ComponentProps, useMemo } from 'react'
 import { ASSIGNMENT_STATUS_BADGE, AssignmentStatusBadgeType } from './variants'
 
-type PathProductItemAssignmentProps = ComponentProps<'div'> & {
-  component?: ElementType
-}
-
-function PathProductItemAssignment({
-  component = 'div',
-  ...props
-}: PathProductItemAssignmentProps) {
-  const Component = component
-
+type PathProductItemAssignmentProps = ComponentProps<'div'>
+function PathProductItemAssignment({ ...props }: PathProductItemAssignmentProps) {
   return (
-    <Component
-      className='flex min-h-[5rem] w-[22.75rem] flex-row items-center justify-between'
+    <Flex
+      direction='row'
+      align='center'
+      justify='between'
+      className='min-h-[5rem] w-[22.75rem]'
       {...props}
     />
   )
@@ -35,14 +30,17 @@ function LeftSection({
   ...props
 }: LeftSectionProps) {
   return (
-    <div className='flex w-[16.75rem] flex-row items-center gap-[0.75rem]'>
+    <Flex
+      direction='row'
+      align='center'
+      className='w-[16.75rem] gap-[0.75rem]'>
       <ImageSection
         src={src}
         alt={alt}
         size='xxs'
         {...props}
       />
-      <div className='flex flex-col'>
+      <Flex direction='column'>
         <Typography
           color='alternative'
           variant='caption-1'
@@ -60,8 +58,8 @@ function LeftSection({
           variant='caption-1'>
           {endDate}
         </Typography>
-      </div>
-    </div>
+      </Flex>
+    </Flex>
   )
 }
 type StatusBadgeProps = ComponentProps<typeof Badge> & {

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemAssignment.tsx
@@ -1,0 +1,92 @@
+import { Badge, ImageSection, Typography } from '@repo/ui/server'
+import { ComponentProps, ElementType, useMemo } from 'react'
+import { ASSIGNMENT_STATUS_BADGE, AssignmentStatusBadgeType } from './variants'
+
+type PathProductItemAssignmentProps = ComponentProps<'div'> & {
+  component?: ElementType
+}
+
+function PathProductItemAssignment({
+  component = 'div',
+  ...props
+}: PathProductItemAssignmentProps) {
+  const Component = component
+
+  return (
+    <Component
+      className='flex min-h-[5rem] w-[22.75rem] flex-row items-center justify-between'
+      {...props}
+    />
+  )
+}
+
+type LeftSectionProps = ComponentProps<typeof ImageSection> & {
+  pathName: string
+  assignmentName: string
+  endDate: string
+}
+
+function LeftSection({
+  src,
+  alt = 'path-assignment-image',
+  pathName = '',
+  assignmentName = '',
+  endDate = '',
+  ...props
+}: LeftSectionProps) {
+  return (
+    <div className='flex w-[16.75rem] flex-row items-center gap-[0.75rem]'>
+      <ImageSection
+        src={src}
+        alt={alt}
+        size='xxs'
+        {...props}
+      />
+      <div className='flex flex-col'>
+        <Typography
+          color='alternative'
+          variant='caption-1'
+          className='mb-[0.25rem]'>
+          {pathName}
+        </Typography>
+        <Typography
+          variant='label-reading'
+          fontWeight='semibold'
+          className='mb-[0.5rem] line-clamp-1'>
+          {assignmentName}
+        </Typography>
+        <Typography
+          color='alternative'
+          variant='caption-1'>
+          {endDate}
+        </Typography>
+      </div>
+    </div>
+  )
+}
+type StatusBadgeProps = ComponentProps<typeof Badge> & {
+  badgeType: AssignmentStatusBadgeType
+}
+
+function StatusBadge({ badgeType, ...props }: StatusBadgeProps) {
+  const { badgeColor, badgeLabel } = useMemo(() => {
+    return {
+      badgeColor: ASSIGNMENT_STATUS_BADGE[badgeType].COLOR,
+      badgeLabel: ASSIGNMENT_STATUS_BADGE[badgeType].LABEL
+    }
+  }, [badgeType])
+
+  return (
+    <Badge
+      color={badgeColor}
+      size='m'
+      {...props}>
+      {badgeLabel}
+    </Badge>
+  )
+}
+
+PathProductItemAssignment.LeftSection = LeftSection
+PathProductItemAssignment.StatusBadge = StatusBadge
+
+export default PathProductItemAssignment

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemBasic.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemBasic.tsx
@@ -1,17 +1,14 @@
 import { useMemo } from 'react'
-import { ComponentProps, ElementType } from 'react'
+import { ComponentProps } from 'react'
 import { PATH_STATUS_BADGE, PathStatusBadgeType } from './variants'
-import { Badge, ImageSection, Typography } from '@repo/ui/server'
+import { Badge, Flex, ImageSection, Typography } from '@repo/ui/server'
 
-type PathProductItemBasicProps = ComponentProps<'div'> & {
-  component?: ElementType
-}
-function PathProductItemBasic({ component = 'div', ...props }: PathProductItemBasicProps) {
-  const Component = component
-
+type PathProductItemBasicProps = ComponentProps<'div'>
+function PathProductItemBasic({ ...props }: PathProductItemBasicProps) {
   return (
-    <Component
-      className='flex min-h-[20.813rem] max-w-[18.75rem] flex-col gap-[0.75rem]'
+    <Flex
+      direction='column'
+      className='min-h-[20.813rem] max-w-[18.75rem] gap-[0.75rem]'
       {...props}
     />
   )
@@ -46,11 +43,13 @@ function BadgeList({ level, category, badgeType = 'SCHEDULE' }: BadgeListProps) 
   }, [badgeType])
 
   return (
-    <div className='flex flex-row gap-[0.375rem]'>
+    <Flex
+      direction='row'
+      className='gap-[0.375rem]'>
       <Badge>Lv.{level}</Badge>
       <Badge>{category}</Badge>
       <Badge color={badgeColor}>{badgeLabel}</Badge>
-    </div>
+    </Flex>
   )
 }
 
@@ -61,7 +60,9 @@ type TextContentListProps = ComponentProps<'div'> & {
 
 function TextContentList({ name, period }: TextContentListProps) {
   return (
-    <div className='flex flex-col gap-[0.375rem]'>
+    <Flex
+      direction='column'
+      className='gap-[0.375rem]'>
       <Typography
         className='line-clamp-2'
         variant='label-normal'
@@ -74,7 +75,7 @@ function TextContentList({ name, period }: TextContentListProps) {
         fontWeight='regular'>
         {period}
       </Typography>
-    </div>
+    </Flex>
   )
 }
 

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemProgress.stories.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemProgress.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import PathProductItemProgress from './PathProductItemProgress'
 
 const meta = {
-  title: 'Molecule/PathProductItem/PathProductItemProgress',
+  title: 'ProductItem/Progress',
   component: PathProductItemProgress,
   parameters: {
     layout: 'centered',

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemProgress.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemProgress.tsx
@@ -1,18 +1,15 @@
-import { ComponentProps, ElementType, useMemo } from 'react'
+import { ComponentProps, useMemo } from 'react'
 
 import { PATH_STATUS_BADGE, PathStatusBadgeType } from './variants'
-import { Badge, ImageSection, ProgressBar, Typography } from '@repo/ui/server'
+import { Badge, Flex, ImageSection, ProgressBar, Typography } from '@repo/ui/server'
 
-type PathProductItemProgressProps = ComponentProps<'div'> & {
-  component?: ElementType
-}
+type PathProductItemProgressProps = ComponentProps<'div'>
 
-function PathProductItemProgress({ component = 'div', ...props }: PathProductItemProgressProps) {
-  const Component = component
-
+function PathProductItemProgress({ ...props }: PathProductItemProgressProps) {
   return (
-    <Component
-      className='flex min-h-[7.5rem] max-w-[22.75rem] flex-row gap-[0.75rem]'
+    <Flex
+      direction='row'
+      className='min-h-[7.5rem] max-w-[22.75rem] gap-[0.75rem]'
       {...props}
     />
   )
@@ -49,13 +46,18 @@ function RightSection({ level, category, name, badgeType = 'SCHEDULE', value }: 
   }, [badgeType])
 
   return (
-    <div className='flex w-[100%] flex-col justify-between'>
+    <Flex
+      direction='column'
+      justify='between'
+      className='w-[100%]'>
       <div>
-        <div className='mb-[0.75rem] flex flex-row gap-[0.375rem]'>
+        <Flex
+          direction='row'
+          className='mb-[0.75rem] gap-[0.375rem]'>
           <Badge>Lv.{level}</Badge>
           <Badge>{category}</Badge>
           <Badge color={badgeColor}>{badgeLabel}</Badge>
-        </div>
+        </Flex>
         <Typography
           variant='label-reading'
           fontWeight='semibold'
@@ -64,7 +66,7 @@ function RightSection({ level, category, name, badgeType = 'SCHEDULE', value }: 
         </Typography>
       </div>
       <ProgressBar value={value} />
-    </div>
+    </Flex>
   )
 }
 

--- a/apps/web/src/shared/ui/path-product-item/index.tsx
+++ b/apps/web/src/shared/ui/path-product-item/index.tsx
@@ -1,2 +1,3 @@
 export { default as PathProductItemBasic } from './PathProductItemBasic'
 export { default as PathProductItemProgress } from './PathProductItemProgress'
+export { default as PathProductItemAssignment } from './PathProductItemAssignment'

--- a/apps/web/src/shared/ui/path-product-item/variants.ts
+++ b/apps/web/src/shared/ui/path-product-item/variants.ts
@@ -1,20 +1,39 @@
+import { BadgeColors } from '@repo/ui/components/badge/variants'
+
 export const PATH_STATUS_BADGE = {
   SCHEDULE: {
     LABEL: '진행 예정',
-    COLOR: 'purple'
+    COLOR: BadgeColors.PURPLE
   },
   IN_PROGRESS: {
     LABEL: '진행 중',
-    COLOR: 'orange'
+    COLOR: BadgeColors.ORANGE
   },
   COMPLETED: {
     LABEL: '수료',
-    COLOR: 'green'
+    COLOR: BadgeColors.GREEN
   },
   NOT_COMPLETE: {
     LABEL: '미수료',
-    COLOR: 'red'
+    COLOR: BadgeColors.RED
   }
 } as const
 
 export type PathStatusBadgeType = keyof typeof PATH_STATUS_BADGE
+
+export const ASSIGNMENT_STATUS_BADGE = {
+  SUBMIT_AVAILABLE: {
+    LABEL: '제출 가능',
+    COLOR: BadgeColors.BLUE
+  },
+  SUBMITTED: {
+    LABEL: '제출 완료',
+    COLOR: BadgeColors.GREEN
+  },
+  DEADLINE_PASSED: {
+    LABEL: '제출 마감',
+    COLOR: BadgeColors.GRAY
+  }
+} as const
+
+export type AssignmentStatusBadgeType = keyof typeof ASSIGNMENT_STATUS_BADGE

--- a/packages/ui/src/components/badge/index.tsx
+++ b/packages/ui/src/components/badge/index.tsx
@@ -9,8 +9,8 @@ export const badgeVariants = cva(
   {
     variants: {
       size: {
-        [BadgeSizes.M]: 'min-h-[2rem] px-[0.625rem] text-l-reading',
-        [BadgeSizes.S]: 'min-h-[1.5rem] px-[0.375rem] text-c1'
+        [BadgeSizes.M]: 'h-[2rem] px-[0.625rem] text-l-reading',
+        [BadgeSizes.S]: 'h-[1.5rem] px-[0.375rem] text-c1'
       },
       color: {
         [BadgeColors.GRAY]: 'bg-neutral-99 text-neutral-10',
@@ -39,7 +39,7 @@ function Badge({ component = 'div', size, color, className, asChild, ...props }:
 
   return (
     <Component
-      className={`${badgeVariants({ size, color })} ${className}`}
+      className={`flex-shrink-0 ${badgeVariants({ size, color })} ${className}`}
       {...props}
     />
   )


### PR DESCRIPTION
## 🌱 작업 개요

- PathProductAssignment 공용 컴포넌트를 추가합니다.

## 🧐 중요한 변경 사항

<img width="835" alt="image" src="https://github.com/user-attachments/assets/1bd2a1ad-84a2-4936-a06f-5e096cca6a69">

```js
//@Example
<PathProductItemAssignment {...args}>
    <PathProductItemAssignment.LeftSection
        src='/avif/placeholder.avif'
        alt='placeholder image'
        pathName='HTML & CSS'
        assignmentName='과제 이름 1줄까지 과제 이름 1줄까지'
        endDate='~ 2024.10.06'
    />
    <PathProductItemAssignment.StatusBadge badgeType='SUBMITTED' />
</PathProductItemAssignment>
```

## 👻 질문 사항

