### PR TITLE
feat: PathProductItemDone 컴포넌트를 추가합니다.

### DIFF
--- a/apps/web/src/shared/ui/path-product-item/PathProductItemDone.stories.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemDone.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import PathProductItemDone from './PathProductItemDone'
+
+const meta = {
+  title: 'ProductItem/Done',
+  component: PathProductItemDone,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '완료된 패스의 컨텐츠를 보여줄 수 있는 Item 컴포넌트 입니다.'
+      }
+    }
+  },
+  tags: ['autodocs'],
+  decorators: (Story) => (
+    <div className='px-40 py-10'>
+      <Story />
+    </div>
+  )
+} satisfies Meta<typeof PathProductItemDone>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  render: (args) => (
+    <div className='mx-auto w-full max-w-[22.75rem]'>
+      <PathProductItemDone>
+        <PathProductItemDone.ContentSection
+          level={1}
+          category='카테고리'
+          title='패스 이름 2줄까지 패스 이름 2줄까지 패스 이름 2줄까지 패스 이름 2줄까지 패스 이름'
+          period='2024.01.01 ~ 2024.01.01'
+        />
+        <PathProductItemDone.FooterSection onClick={() => {}} />
+      </PathProductItemDone>
+    </div>
+  )
+}

--- a/apps/web/src/shared/ui/path-product-item/PathProductItemDone.tsx
+++ b/apps/web/src/shared/ui/path-product-item/PathProductItemDone.tsx
@@ -1,0 +1,92 @@
+import { Icon } from '@repo/ui/client'
+import { Badge, Flex, ImageSection, TextButton, Typography } from '@repo/ui/server'
+import { ComponentProps } from 'react'
+
+type PathProductItemDoneProps = ComponentProps<'div'>
+
+function PathProductItemDone({ ...props }: PathProductItemDoneProps) {
+  return (
+    <Flex
+      direction='column'
+      className='max-w-[22.75rem] gap-[0.75rem]'
+      {...props}
+    />
+  )
+}
+
+type ContentSectionProps = ComponentProps<'div'> & {
+  level: number
+  category: string
+  title: string
+  period: string
+}
+
+function ContentSection({ level, category, title, period, ...props }: ContentSectionProps) {
+  return (
+    <Flex
+      direction='row'
+      align='center'
+      className='w-[100%] gap-[0.75rem]'>
+      <ImageSection
+        size='xs'
+        src='/avif/placeholder.avif'
+        alt='Placeholder Image'
+      />
+      <Flex
+        direction='column'
+        className='gap-[0.75rem]'
+        {...props}>
+        <Flex
+          direction='row'
+          className='gap-[0.75rem]'>
+          <Badge>Lv.{level}</Badge>
+          <Badge>{category}</Badge>
+          <Badge color={'green'}>수료</Badge>
+        </Flex>
+        <Typography
+          variant='label-reading'
+          fontWeight='semibold'
+          className='line-clamp-2'>
+          {title}
+        </Typography>
+        <Typography
+          color='alternative'
+          variant='caption-2'>
+          {period}
+        </Typography>
+      </Flex>
+    </Flex>
+  )
+}
+
+type FooterSectionProps = ComponentProps<'div'> & {
+  onClick: () => void
+}
+
+function FooterSection({ onClick, ...props }: FooterSectionProps) {
+  return (
+    <Flex
+      direction='column'
+      className='w-[100%] gap-[0.75rem]'
+      {...props}>
+      <div className='h-[1px] w-full bg-[#17171715]' />
+      <TextButton
+        size='small'
+        className='w-full justify-between'
+        onClick={onClick}
+        rightIcon={
+          <Icon
+            name='RightOutlined'
+            size='16'
+          />
+        }>
+        수료증 받기
+      </TextButton>
+    </Flex>
+  )
+}
+
+PathProductItemDone.ContentSection = ContentSection
+PathProductItemDone.FooterSection = FooterSection
+
+export default PathProductItemDone

--- a/apps/web/src/shared/ui/path-product-item/index.tsx
+++ b/apps/web/src/shared/ui/path-product-item/index.tsx
@@ -1,3 +1,4 @@
 export { default as PathProductItemBasic } from './PathProductItemBasic'
 export { default as PathProductItemProgress } from './PathProductItemProgress'
 export { default as PathProductItemAssignment } from './PathProductItemAssignment'
+export { default as PathProductItemDone } from './PathProductItemDone'


### PR DESCRIPTION
## 🌱 작업 개요

- PathProductItemDone 컴포넌트를 추가합니다.

## 🧐 중요한 변경 사항
<img width="832" alt="image" src="https://github.com/user-attachments/assets/be7adc07-a16a-43aa-a2d5-23fb570770fd">

```js
<PathProductItemDone>
   <PathProductItemDone.ContentSection
      level={1}
      category='카테고리'
      title='패스 이름 2줄까지 패스 이름 2줄까지 패스 이름 2줄까지 패스 이름 2줄까지 패스 이름'
      period='2024.01.01 ~ 2024.01.01'
   />
   <PathProductItemDone.FooterSection onClick={() => {}} />
</PathProductItemDone>
```
<!--스크린샷이 있다면 추가해주세요.-->
<!--공용 컴포넌트, 린트 설정 등에 변경이 있다면 꼭 공유해주세요.-->

## 👻 질문 사항

<!--함께 고민하고 싶은 것이 있다면 작성해주세요.-->
<!--중점적으로 피드백 받고 싶은 부분을 작성해주세요.-->
