### PR TITLE
feat: 로그인/회원가입 api를 추가합니다.

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -56,6 +56,3 @@ jobs:
 
       - name: Run format
         run: pnpm format
-
-      - name: Run build
-        run: pnpm build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-echo 'building...'
-pnpm run build

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,2 +1,6 @@
-ANI_WEB_AUTH_URL=http://localhost:8080
-ANI_WEB_API_URL=http://localhost:9090
+NEXT_PUBLIC_AUTH_URL=http://localhost:8080
+NEXT_PUBLIC_API_URL=http://localhost:9090
+
+AUTH_SECRET="" # Added by `npx auth`. Read more: https://cli.authjs.dev
+AUTH_DISCORD_ID=""
+AUTH_DISCORD_SECRET=""

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_AUTH_URL=http://localhost:8080
 NEXT_PUBLIC_API_URL=http://localhost:9090
 NEXT_PUBLIC_CLIENT_URL=로컬환경주소
+NEXTAUTH_URL=로컬환경주소
 
 AUTH_SECRET=1o4a2BS4EoKczurqeIkUbCNgyaAlsq2TkwTuVNDBnxo= # Added by `npx auth`. Read more: https://cli.authjs.dev

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,3 +1,4 @@
+NEXT_PUBLIC_CLIENT_URL=http://localhost:3000
 NEXT_PUBLIC_AUTH_URL=http://localhost:8080
 NEXT_PUBLIC_API_URL=http://localhost:9090
 

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,7 +1,5 @@
-NEXT_PUBLIC_CLIENT_URL=http://localhost:3000
 NEXT_PUBLIC_AUTH_URL=http://localhost:8080
 NEXT_PUBLIC_API_URL=http://localhost:9090
+NEXT_PUBLIC_CLIENT_URL=로컬환경주소
 
-AUTH_SECRET="" # Added by `npx auth`. Read more: https://cli.authjs.dev
-AUTH_DISCORD_ID=""
-AUTH_DISCORD_SECRET=""
+AUTH_SECRET=1o4a2BS4EoKczurqeIkUbCNgyaAlsq2TkwTuVNDBnxo= # Added by `npx auth`. Read more: https://cli.authjs.dev

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,0 +1,2 @@
+ANI_WEB_AUTH_URL=http://localhost:8080
+ANI_WEB_API_URL=http://localhost:9090

--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/auth'
+
+export const { GET, POST } = handlers

--- a/apps/web/app/api/v1/auth/social/discord/callback/route.ts
+++ b/apps/web/app/api/v1/auth/social/discord/callback/route.ts
@@ -12,11 +12,9 @@ export async function GET(request: Request) {
       return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL ?? '/error/404')
     }
 
-    const response = await oauthLogin({ provider: 'discord', state, code })
-
-    const urlObject = new URL(response.url)
-    const accessToken = urlObject.searchParams.get('accessToken')
-    const refreshToken = urlObject.searchParams.get('refreshToken')
+    const {
+      data: { accessToken, refreshToken }
+    } = await oauthLogin({ provider: 'discord', state, code })
 
     if (!accessToken || !refreshToken) {
       return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL ?? '/error/404')

--- a/apps/web/app/api/v1/auth/social/discord/callback/route.ts
+++ b/apps/web/app/api/v1/auth/social/discord/callback/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { signIn } from '@/auth'
+import { oauthLogin } from '@/features/auth/api/oauth-login'
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const code = searchParams.get('code')
+    const state = searchParams.get('state')
+
+    if (!code || !state) {
+      return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL ?? '/error/404')
+    }
+
+    const response = await oauthLogin({ provider: 'discord', state, code })
+
+    const urlObject = new URL(response.url)
+    const accessToken = urlObject.searchParams.get('accessToken')
+    const refreshToken = urlObject.searchParams.get('refreshToken')
+
+    if (!accessToken || !refreshToken) {
+      return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL ?? '/error/404')
+    }
+
+    await signIn('discord', {
+      accessToken,
+      refreshToken,
+      redirect: false
+    })
+
+    return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL)
+  } catch (error) {
+    return NextResponse.redirect(`${process.env.NEXT_PUBLIC_CLIENT_URL}/error`)
+  }
+}

--- a/apps/web/app/error/page.tsx
+++ b/apps/web/app/error/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page({ searchParams }: { searchParams: { code: string } }) {
+  return <div>Error: {searchParams.code}</div>
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { Flex } from '@repo/ui/server'
 import Header from '@/shared/ui/header'
 import LoginModal from '@/features/auth/ui/login-modal'
 import SignupModal from '@/features/auth/ui/signup-modal'
+import { SessionProvider } from 'next-auth/react'
 
 // TODO: 로그인 상태 추가
 const isLoggedIn = false
@@ -18,20 +19,22 @@ export default function RootLayout({
     <html
       className={`${pretendardFont.variable}`}
       lang='ko'>
-      <Flex
-        asChild
-        direction={'column'}
-        className='w-full'>
-        <body className='bg-background-alternative'>
-          <div id='portal-container'></div>
-          <div className='mb-[3.25rem]'>
-            <Header isLoggedIn={isLoggedIn} />
-          </div>
-          {children}
-          <LoginModal />
-          <SignupModal />
-        </body>
-      </Flex>
+      <SessionProvider>
+        <Flex
+          asChild
+          direction={'column'}
+          className='w-full'>
+          <body className='bg-background-alternative'>
+            <div id='portal-container'></div>
+            <div className='mb-[3.25rem]'>
+              <Header />
+            </div>
+            {children}
+            <LoginModal />
+            <SignupModal />
+          </body>
+        </Flex>
+      </SessionProvider>
     </html>
   )
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,9 +7,6 @@ import LoginModal from '@/features/auth/ui/login-modal'
 import SignupModal from '@/features/auth/ui/signup-modal'
 import { SessionProvider } from 'next-auth/react'
 
-// TODO: 로그인 상태 추가
-const isLoggedIn = false
-
 export default function RootLayout({
   children
 }: Readonly<{

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,10 +16,11 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-slot": "^1.1.0",
+    "@repo/sdu": "workspace:*",
     "@repo/ui": "workspace:*",
     "@repo/util": "workspace:*",
-    "@repo/sdu": "workspace:*",
     "next": "^14.2.16",
+    "next-auth": "5.0.0-beta.25",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.53.2",

--- a/apps/web/src/__mock__/types/auth.ts
+++ b/apps/web/src/__mock__/types/auth.ts
@@ -12,7 +12,10 @@ export type LoginRequestType = {
 
 export type AuthResponse = {
   status: number
-  message?: string
+  data: {
+    accessToken: string
+    refreshToken: string
+  }
 }
 
 export type SignupRequestType = {

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,0 +1,32 @@
+import NextAuth, { NextAuthResult } from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import Discord from 'next-auth/providers/discord'
+
+const nextAuthResult = NextAuth({
+  providers: [
+    Discord,
+    Credentials({
+      credentials: {
+        email: {},
+        password: {}
+      },
+      authorize: async (credentials) => {
+        let user = null
+        try {
+          const response = await fetch(`${process.env.NEXT_PUBLIC_AUTH_URL}/api/v1/auth/login`, {
+            method: 'POST',
+            body: JSON.stringify(credentials)
+          })
+          const data = await response.json()
+          user = data
+        } catch (error) {
+          console.error(error)
+        }
+        return user
+      }
+    })
+  ]
+})
+
+export const auth: NextAuthResult['auth'] = nextAuthResult.auth
+export const { handlers, signIn, signOut } = nextAuthResult

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,13 +1,46 @@
 import NextAuth, { NextAuthResult } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
-import Discord from 'next-auth/providers/discord'
-import { loginModalSchema } from './entities/auth/model'
+import { discordOauthSchema, loginModalSchema } from './entities/auth/model'
 import { login } from './features/auth/api/login'
 
 const nextAuthResult = NextAuth({
+  secret: process.env.NEXTAUTH_SECRET,
+  useSecureCookies: process.env.NODE_ENV === 'production',
+  cookies: {
+    csrfToken: {
+      name: 'next-auth.csrf-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production'
+      }
+    }
+  },
   providers: [
-    Discord,
     Credentials({
+      id: 'discord',
+      credentials: {
+        accessToken: { label: 'Access Token', type: 'text' },
+        refreshToken: { label: 'Refresh Token', type: 'text' }
+      },
+      authorize: async (credentials) => {
+        try {
+          const { accessToken, refreshToken } = await discordOauthSchema.parseAsync(credentials)
+
+          return {
+            id: 'discord-user',
+            type: 'oauth',
+            accessToken,
+            refreshToken
+          }
+        } catch (error) {
+          return null
+        }
+      }
+    }),
+    Credentials({
+      id: 'credentials',
       credentials: {
         email: { label: 'Email', type: 'text' },
         password: { label: 'Password', type: 'password' }
@@ -22,6 +55,8 @@ const nextAuthResult = NextAuth({
           const { accessToken, refreshToken } = response.data
 
           return {
+            id: 'credentials-user',
+            type: 'credentials',
             accessToken,
             refreshToken
           }
@@ -32,20 +67,17 @@ const nextAuthResult = NextAuth({
     })
   ],
   callbacks: {
-    jwt: async ({ token, user }) => {
-      if (user) {
-        token.accessToken = user.accessToken
-        token.refreshToken = user.refreshToken
+    jwt: async ({ token, account }) => {
+      if (account?.type === 'oauth') {
+        console.log(account, 'account')
+        token.accessToken = account.accessToken as string
+        token.refreshToken = account.refreshToken as string
       }
       return token
     },
-    async session({ session, token }) {
-      if (typeof token.accessToken === 'string') {
-        session.accessToken = token.accessToken
-      }
-      if (typeof token.refreshToken === 'string') {
-        session.refreshToken = token.refreshToken
-      }
+    session: async ({ session, token }) => {
+      session.accessToken = token.accessToken as string
+      session.refreshToken = token.refreshToken as string
       return session
     }
   }

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,21 +1,14 @@
 import NextAuth, { NextAuthResult } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
-import { discordOauthSchema, loginModalSchema } from './entities/auth/model'
+import { loginModalSchema, tokenSchema } from './entities/auth/model'
 import { login } from './features/auth/api/login'
 
 const nextAuthResult = NextAuth({
   secret: process.env.NEXTAUTH_SECRET,
   useSecureCookies: process.env.NODE_ENV === 'production',
-  cookies: {
-    csrfToken: {
-      name: 'next-auth.csrf-token',
-      options: {
-        httpOnly: true,
-        sameSite: 'lax',
-        path: '/',
-        secure: process.env.NODE_ENV === 'production'
-      }
-    }
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60
   },
   providers: [
     Credentials({
@@ -26,7 +19,7 @@ const nextAuthResult = NextAuth({
       },
       authorize: async (credentials) => {
         try {
-          const { accessToken, refreshToken } = await discordOauthSchema.parseAsync(credentials)
+          const { accessToken, refreshToken } = await tokenSchema.parseAsync(credentials)
 
           return {
             id: 'discord-user',
@@ -48,11 +41,12 @@ const nextAuthResult = NextAuth({
       authorize: async (credentials) => {
         try {
           const { email, password } = await loginModalSchema.parseAsync(credentials)
+
           const response = await login({ email, password })
 
           if (!response) return null
 
-          const { accessToken, refreshToken } = response.data
+          const { accessToken, refreshToken } = await tokenSchema.parseAsync(response.data)
 
           return {
             id: 'credentials-user',
@@ -61,26 +55,34 @@ const nextAuthResult = NextAuth({
             refreshToken
           }
         } catch (error) {
+          if (error instanceof Error) {
+            console.error('로그인 상세 에러:', {
+              name: error.name,
+              message: error.message,
+              stack: error.stack
+            })
+          }
           return null
         }
       }
     })
   ],
   callbacks: {
-    jwt: async ({ token, account }) => {
+    async jwt({ token, account }) {
       if (account?.type === 'oauth') {
-        console.log(account, 'account')
-        token.accessToken = account.accessToken as string
-        token.refreshToken = account.refreshToken as string
+        token.accessToken = account.accessToken
+        token.refreshToken = account.refreshToken
       }
       return token
     },
-    session: async ({ session, token }) => {
+
+    async session({ session, token }) {
       session.accessToken = token.accessToken as string
       session.refreshToken = token.refreshToken as string
       return session
     }
-  }
+  },
+  debug: process.env.NODE_ENV === 'development'
 })
 
 export const auth: NextAuthResult['auth'] = nextAuthResult.auth

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,31 +1,54 @@
 import NextAuth, { NextAuthResult } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import Discord from 'next-auth/providers/discord'
+import { loginModalSchema } from './entities/auth/model'
+import { login } from './features/auth/api/login'
 
 const nextAuthResult = NextAuth({
   providers: [
     Discord,
     Credentials({
       credentials: {
-        email: {},
-        password: {}
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' }
       },
       authorize: async (credentials) => {
-        let user = null
         try {
-          const response = await fetch(`${process.env.NEXT_PUBLIC_AUTH_URL}/api/v1/auth/login`, {
-            method: 'POST',
-            body: JSON.stringify(credentials)
-          })
-          const data = await response.json()
-          user = data
+          const { email, password } = await loginModalSchema.parseAsync(credentials)
+          const response = await login({ email, password })
+
+          if (!response) return null
+
+          const { accessToken, refreshToken } = response.data
+
+          return {
+            accessToken,
+            refreshToken
+          }
         } catch (error) {
-          console.error(error)
+          return null
         }
-        return user
       }
     })
-  ]
+  ],
+  callbacks: {
+    jwt: async ({ token, user }) => {
+      if (user) {
+        token.accessToken = user.accessToken
+        token.refreshToken = user.refreshToken
+      }
+      return token
+    },
+    async session({ session, token }) {
+      if (typeof token.accessToken === 'string') {
+        session.accessToken = token.accessToken
+      }
+      if (typeof token.refreshToken === 'string') {
+        session.refreshToken = token.refreshToken
+      }
+      return session
+    }
+  }
 })
 
 export const auth: NextAuthResult['auth'] = nextAuthResult.auth

--- a/apps/web/src/entities/auth/model/discordOauthSchema.ts
+++ b/apps/web/src/entities/auth/model/discordOauthSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const discordOauthSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string()
+})
+
+export type DiscordOauthSchema = z.infer<typeof discordOauthSchema>

--- a/apps/web/src/entities/auth/model/discordOauthSchema.ts
+++ b/apps/web/src/entities/auth/model/discordOauthSchema.ts
@@ -1,8 +1,0 @@
-import { z } from 'zod'
-
-export const discordOauthSchema = z.object({
-  accessToken: z.string(),
-  refreshToken: z.string()
-})
-
-export type DiscordOauthSchema = z.infer<typeof discordOauthSchema>

--- a/apps/web/src/entities/auth/model/index.ts
+++ b/apps/web/src/entities/auth/model/index.ts
@@ -1,3 +1,3 @@
 export { loginModalSchema, type LoginModalFormData } from './loginModalSchema'
 export { signupModalSchema, type SignupModalFormData } from './signupModalSchema'
-export { discordOauthSchema, type DiscordOauthSchema } from './discordOauthSchema'
+export { tokenSchema, type TokenSchema } from './tokenSchema'

--- a/apps/web/src/entities/auth/model/index.ts
+++ b/apps/web/src/entities/auth/model/index.ts
@@ -1,2 +1,3 @@
 export { loginModalSchema, type LoginModalFormData } from './loginModalSchema'
 export { signupModalSchema, type SignupModalFormData } from './signupModalSchema'
+export { discordOauthSchema, type DiscordOauthSchema } from './discordOauthSchema'

--- a/apps/web/src/entities/auth/model/loginModalSchema.ts
+++ b/apps/web/src/entities/auth/model/loginModalSchema.ts
@@ -2,13 +2,7 @@ import { z } from 'zod'
 
 export const loginModalSchema = z.object({
   email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, '유효한 이메일 형식이 아닙니다'),
-  password: z
-    .string()
-    .min(8, '비밀번호는 최소 8자 이상이어야 합니다')
-    .regex(
-      /^(?=.*[a-z])(?=.*\d)(?=.*[@$!%*?&])[a-z\d@$!%*?&]{8,}$/,
-      '비밀번호는 최소 하나의 소문자, 숫자 및 특수문자를 포함해야 합니다'
-    )
+  password: z.string().max(10, '비밀번호는 최대 10자 이하여야 합니다')
 })
 
 export type LoginModalFormData = z.infer<typeof loginModalSchema>

--- a/apps/web/src/entities/auth/model/tokenSchema.ts
+++ b/apps/web/src/entities/auth/model/tokenSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const tokenSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string()
+})
+
+export type TokenSchema = z.infer<typeof tokenSchema>

--- a/apps/web/src/features/auth/api/index.ts
+++ b/apps/web/src/features/auth/api/index.ts
@@ -1,1 +1,3 @@
 export { signup } from './signup'
+export { oauthLogin } from './oauth-login'
+export { login } from './login'

--- a/apps/web/src/features/auth/api/index.ts
+++ b/apps/web/src/features/auth/api/index.ts
@@ -1,2 +1,1 @@
-export { login } from './login'
 export { signup } from './signup'

--- a/apps/web/src/features/auth/api/login.ts
+++ b/apps/web/src/features/auth/api/login.ts
@@ -7,7 +7,10 @@ export async function login(loginData: LoginRequestType) {
     const response = await fetch(process.env.NEXT_PUBLIC_API_URL + END_POINT.AUTH.LOGIN, {
       method: HTTP_METHODS.POST,
       headers: HTTP_HEADERS.JSON,
-      body: JSON.stringify(loginData)
+      body: JSON.stringify({
+        ...loginData,
+        type: 'ani'
+      })
     })
 
     console.log('response', response)

--- a/apps/web/src/features/auth/api/login.ts
+++ b/apps/web/src/features/auth/api/login.ts
@@ -4,7 +4,7 @@ import { END_POINT } from '../config/auth-config'
 
 export async function login(loginData: LoginRequestType) {
   try {
-    const response = await fetch(process.env.NEXT_PUBLIC_API_URL + END_POINT.AUTH.LOGIN, {
+    const response = await fetch(process.env.NEXT_PUBLIC_AUTH_URL + END_POINT.AUTH.LOGIN, {
       method: HTTP_METHODS.POST,
       headers: HTTP_HEADERS.JSON,
       body: JSON.stringify({

--- a/apps/web/src/features/auth/api/oauth-login.ts
+++ b/apps/web/src/features/auth/api/oauth-login.ts
@@ -1,0 +1,23 @@
+import type { AuthResponse } from '@/__mock__/types/auth'
+
+export async function oauthLogin({
+  provider,
+  state,
+  code
+}: {
+  provider: string
+  state: string
+  code: string
+}) {
+  const baseUrl = `${process.env.NEXT_PUBLIC_AUTH_URL}/api/v1/auth/social/${provider}/callback`
+  const parmas = [`state=${state}`, `code=${code}`].join('&')
+
+  const response = await fetch(`${baseUrl}?${parmas}`)
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.message)
+  }
+
+  return response
+}

--- a/apps/web/src/features/auth/api/oauth-login.ts
+++ b/apps/web/src/features/auth/api/oauth-login.ts
@@ -12,12 +12,21 @@ export async function oauthLogin({
   const baseUrl = `${process.env.NEXT_PUBLIC_AUTH_URL}/api/v1/auth/social/${provider}/callback`
   const parmas = [`state=${state}`, `code=${code}`].join('&')
 
-  const response = await fetch(`${baseUrl}?${parmas}`)
+  const response = await fetch(`${baseUrl}?${parmas}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+
+  console.log('response', response)
 
   if (!response.ok) {
+    console.log('에러 발생')
     const error = await response.json()
     throw new Error(error.message)
   }
 
-  return response
+  const data = await response.json()
+  return data
 }

--- a/apps/web/src/features/auth/api/signup.ts
+++ b/apps/web/src/features/auth/api/signup.ts
@@ -4,10 +4,10 @@ import { END_POINT } from '../config/auth-config'
 
 export async function signup(signupData: SignupRequestType) {
   try {
-    const response = await fetch(process.env.NEXT_PUBLIC_API_URL + END_POINT.AUTH.SIGNUP, {
+    const response = await fetch(process.env.NEXT_PUBLIC_AUTH_URL + END_POINT.AUTH.SIGNUP, {
       method: HTTP_METHODS.POST,
       headers: HTTP_HEADERS.JSON,
-      body: JSON.stringify(signupData)
+      body: JSON.stringify({ ...signupData, type: 'ani' })
     })
 
     console.log('response', response)

--- a/apps/web/src/features/auth/config/auth-config.ts
+++ b/apps/web/src/features/auth/config/auth-config.ts
@@ -1,7 +1,7 @@
 export const END_POINT = {
   AUTH: {
-    LOGIN: '/auth/login',
-    SIGNUP: '/auth/signup'
+    LOGIN: '/api/v1/auth/login',
+    SIGNUP: '/api/v1/auth'
   }
 }
 

--- a/apps/web/src/features/auth/ui/login-modal/index.tsx
+++ b/apps/web/src/features/auth/ui/login-modal/index.tsx
@@ -20,6 +20,11 @@ function LoginModal() {
   const setIsLoginModalOpen = useAuthModalStore((state) => state.setIsLoginModalOpen)
   const setIsSignupModalOpen = useAuthModalStore((state) => state.setIsSignupModalOpen)
 
+  const handleDiscordLogin = async () => {
+    const DISCORD_AUTH_URL = `${process.env.NEXT_PUBLIC_AUTH_URL}/api/v1/auth/social/discord?type=ani`
+    window.location.href = DISCORD_AUTH_URL
+  }
+
   const {
     register,
     formState: { errors, isSubmitting },
@@ -179,7 +184,8 @@ function LoginModal() {
           disabled={false}
           className='bg-[#5865F2]'
           size='large'
-          fullWidth>
+          fullWidth
+          onClick={handleDiscordLogin}>
           <Flex
             direction='row'
             align='center'

--- a/apps/web/src/features/auth/ui/login-modal/index.tsx
+++ b/apps/web/src/features/auth/ui/login-modal/index.tsx
@@ -12,7 +12,7 @@ import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useAuthModalStore } from '../../model'
 import { type LoginModalFormData, loginModalSchema } from '@/entities/auth/model'
-import { login } from '../../api'
+import { signIn } from 'next-auth/react'
 
 function LoginModal() {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
@@ -22,7 +22,6 @@ function LoginModal() {
 
   const {
     register,
-    handleSubmit,
     formState: { errors, isSubmitting },
     control
   } = useForm<LoginModalFormData>({
@@ -53,16 +52,6 @@ function LoginModal() {
     setIsSignupModalOpen(true)
   }
 
-  const onSubmit = async (formData: LoginModalFormData) => {
-    const response = await login(formData)
-    if (response?.status === 200) {
-      console.log(response.message)
-      onCloseLoginModal()
-    } else {
-      console.error('로그인 실패:', response?.message)
-    }
-  }
-
   return (
     <Modal
       className='p-0'
@@ -71,7 +60,13 @@ function LoginModal() {
       isOpen={isLoginModalOpen}
       onClose={onCloseLoginModal}>
       <form
-        onSubmit={handleSubmit(onSubmit)}
+        action={async (formData) => {
+          await signIn('credentials', {
+            email: formData.get('email'),
+            password: formData.get('password')
+          })
+          onCloseLoginModal()
+        }}
         className='flex min-w-[37.5rem] flex-col gap-[3rem] px-[3.125rem] py-[3rem]'>
         <Flex
           justify='center'

--- a/apps/web/src/features/auth/ui/signup-modal/index.tsx
+++ b/apps/web/src/features/auth/ui/signup-modal/index.tsx
@@ -20,7 +20,8 @@ function SignupModal() {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-    control
+    control,
+    reset
   } = useForm<SignupModalFormData>({
     resolver: zodResolver(signupModalSchema),
     defaultValues: {
@@ -47,13 +48,9 @@ function SignupModal() {
   }
 
   const onSubmit = async (formData: SignupModalFormData) => {
-    const response = await signup(formData)
-    if (response?.status === 201) {
-      console.log(response.message)
-      onCloseSignupModal()
-    } else {
-      console.error('회원가입 실패:', response?.message)
-    }
+    await signup(formData)
+    onCloseSignupModal()
+    reset()
   }
 
   return (

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,1 @@
+export { auth as middleware } from '@/auth'

--- a/apps/web/src/shared/types/index.d.ts
+++ b/apps/web/src/shared/types/index.d.ts
@@ -5,8 +5,8 @@ declare global {
 
   namespace NodeJS {
     interface ProcessEnv {
-      ANI_WEB_AUTH_URL: string
-      ANI_WEB_API_URL: string
+      NEXT_PUBLIC_AUTH_URL: string
+      NEXT_PUBLIC_API_URL: string
     }
   }
 }

--- a/apps/web/src/shared/types/index.d.ts
+++ b/apps/web/src/shared/types/index.d.ts
@@ -10,3 +10,22 @@ declare global {
     }
   }
 }
+
+declare module 'next-auth' {
+  interface User {
+    accessToken: string
+    refreshToken: string
+  }
+
+  interface Session extends DefaultSession {
+    accessToken: string
+    refreshToken: string
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    accessToken: string
+    refreshToken: string
+  }
+}

--- a/apps/web/src/shared/types/index.d.ts
+++ b/apps/web/src/shared/types/index.d.ts
@@ -7,6 +7,7 @@ declare global {
     interface ProcessEnv {
       NEXT_PUBLIC_AUTH_URL: string
       NEXT_PUBLIC_API_URL: string
+      NEXT_PUBLIC_CLIENT_URL: string
     }
   }
 }

--- a/apps/web/src/shared/types/index.d.ts
+++ b/apps/web/src/shared/types/index.d.ts
@@ -13,20 +13,24 @@ declare global {
 }
 
 declare module 'next-auth' {
-  interface User {
-    accessToken: string
-    refreshToken: string
+  interface Session {
+    accessToken?: string
+    refreshToken?: string
+    user: {
+      accessToken?: string
+      refreshToken?: string
+    } & DefaultSession['user']
   }
 
-  interface Session extends DefaultSession {
-    accessToken: string
-    refreshToken: string
+  interface User {
+    accessToken?: string
+    refreshToken?: string
   }
 }
 
 declare module 'next-auth/jwt' {
   interface JWT {
-    accessToken: string
-    refreshToken: string
+    accessToken?: string
+    refreshToken?: string
   }
 }

--- a/apps/web/src/shared/types/index.d.ts
+++ b/apps/web/src/shared/types/index.d.ts
@@ -2,4 +2,11 @@ import { ReactNode } from 'react'
 
 declare global {
   type PropsNeedChildren<P = unknown> = P & { children: ReactNode }
+
+  namespace NodeJS {
+    interface ProcessEnv {
+      ANI_WEB_AUTH_URL: string
+      ANI_WEB_API_URL: string
+    }
+  }
 }

--- a/apps/web/src/shared/ui/dropdown-menu/index.tsx
+++ b/apps/web/src/shared/ui/dropdown-menu/index.tsx
@@ -2,6 +2,7 @@ import { Slot } from '@radix-ui/react-slot'
 import cn from '@repo/util/cn'
 import {
   ComponentProps,
+  ComponentPropsWithoutRef,
   createContext,
   ReactNode,
   useContext,
@@ -107,7 +108,7 @@ function Trigger({ asChild, children, ...props }: TriggerProps) {
   )
 }
 
-type MenuContentProps = ComponentProps<'div'> & {
+type MenuContentProps = ComponentPropsWithoutRef<'div'> & {
   triggerHeight?: string
 }
 
@@ -145,7 +146,7 @@ function MenuItem({ value, onValueSelect, children, ...props }: MenuItemProps) {
 
   return (
     <button
-      className='w-full whitespace-nowrap text-left'
+      className='w-full whitespace-nowrap text-left duration-100 hover:text-label-alternative'
       role='menuitem'
       data-value={value}
       onClick={handleClick}

--- a/apps/web/src/shared/ui/header/Header.stories.tsx
+++ b/apps/web/src/shared/ui/header/Header.stories.tsx
@@ -1,9 +1,9 @@
-import type { Meta, StoryObj, StoryFn } from '@storybook/react'
-import Header from '.'
+import type { Meta, StoryObj } from '@storybook/react'
+import { HeaderInner } from '.'
 
 const meta = {
   title: 'Widget/Header',
-  component: Header,
+  component: HeaderInner,
   parameters: {
     layout: 'centered',
     docs: {
@@ -13,7 +13,7 @@ const meta = {
     }
   },
   tags: ['autodocs']
-} satisfies Meta<typeof Header>
+} satisfies Meta<typeof HeaderInner>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/apps/web/src/shared/ui/header/index.tsx
+++ b/apps/web/src/shared/ui/header/index.tsx
@@ -4,12 +4,10 @@ import { Flex, SolidButton } from '@repo/ui/server'
 import { Icon } from '@repo/ui/client'
 import Logo from '../logo'
 import { useAuthModalStore } from '@/features/auth/model'
+import { useSession } from 'next-auth/react'
 
-type HeaderProps = {
-  isLoggedIn: boolean
-}
-
-function Header({ isLoggedIn }: HeaderProps) {
+function Header() {
+  const isLoggedIn = useSession().data?.user
   const setIsLoginModalOpen = useAuthModalStore((state) => state.setIsLoginModalOpen)
   const onAlarmClick = () => {
     console.log('alarm')

--- a/apps/web/src/shared/ui/header/index.tsx
+++ b/apps/web/src/shared/ui/header/index.tsx
@@ -8,8 +8,11 @@ import { signOut, useSession } from 'next-auth/react'
 import DropdownMenu from '../dropdown-menu'
 import Link from 'next/link'
 
-function Header() {
-  const isLoggedIn = useSession().data
+type Props = {
+  isLoggedIn: boolean
+}
+
+export function HeaderInner({ isLoggedIn }: Props) {
   const setIsLoginModalOpen = useAuthModalStore((state) => state.setIsLoginModalOpen)
   const onAlarmClick = () => {
     console.log('alarm')
@@ -78,6 +81,11 @@ function Header() {
       </header>
     </Flex>
   )
+}
+
+const Header = () => {
+  const { data: session } = useSession()
+  return <HeaderInner isLoggedIn={!!session} />
 }
 
 export default Header

--- a/apps/web/src/shared/ui/header/index.tsx
+++ b/apps/web/src/shared/ui/header/index.tsx
@@ -10,15 +10,11 @@ import Link from 'next/link'
 
 function Header() {
   const isLoggedIn = useSession().data
-  const { data: session } = useSession()
   const setIsLoginModalOpen = useAuthModalStore((state) => state.setIsLoginModalOpen)
   const onAlarmClick = () => {
     console.log('alarm')
   }
-  console.log('isLoggedIn', isLoggedIn)
-  console.log('session', session)
   const onLoginClick = () => {
-    console.log('login', isLoggedIn)
     setIsLoginModalOpen(true)
   }
 

--- a/apps/web/src/shared/ui/header/index.tsx
+++ b/apps/web/src/shared/ui/header/index.tsx
@@ -9,13 +9,16 @@ import DropdownMenu from '../dropdown-menu'
 import Link from 'next/link'
 
 function Header() {
-  const isLoggedIn = useSession().data?.user
+  const isLoggedIn = useSession().data
+  const { data: session } = useSession()
   const setIsLoginModalOpen = useAuthModalStore((state) => state.setIsLoginModalOpen)
   const onAlarmClick = () => {
     console.log('alarm')
   }
-
+  console.log('isLoggedIn', isLoggedIn)
+  console.log('session', session)
   const onLoginClick = () => {
+    console.log('login', isLoggedIn)
     setIsLoginModalOpen(true)
   }
 

--- a/apps/web/src/shared/ui/header/index.tsx
+++ b/apps/web/src/shared/ui/header/index.tsx
@@ -4,7 +4,9 @@ import { Flex, SolidButton } from '@repo/ui/server'
 import { Icon } from '@repo/ui/client'
 import Logo from '../logo'
 import { useAuthModalStore } from '@/features/auth/model'
-import { useSession } from 'next-auth/react'
+import { signOut, useSession } from 'next-auth/react'
+import DropdownMenu from '../dropdown-menu'
+import Link from 'next/link'
 
 function Header() {
   const isLoggedIn = useSession().data?.user
@@ -13,12 +15,12 @@ function Header() {
     console.log('alarm')
   }
 
-  const onMyPageClick = () => {
-    console.log('my-page')
-  }
-
   const onLoginClick = () => {
     setIsLoginModalOpen(true)
+  }
+
+  const onLogoutClick = () => {
+    signOut()
   }
 
   return (
@@ -44,16 +46,24 @@ function Header() {
                 name='BellOutlined'
               />
             </button>
-            <button
-              onClick={onMyPageClick}
-              className='h-9 w-9'
-              aria-label='my-page'
-              type='button'>
-              <Icon
-                size={36}
-                name='UserOutlined'
-              />
-            </button>
+            <DropdownMenu>
+              <DropdownMenu.Trigger aria-label='my-page'>
+                <Icon
+                  size={36}
+                  name='UserOutlined'
+                />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.MenuContent
+                triggerHeight='3rem'
+                className='right-0'>
+                <DropdownMenu.MenuItem value='mypage'>
+                  <Link href='/mypage'>마이페이지</Link>
+                </DropdownMenu.MenuItem>
+                <DropdownMenu.MenuItem value='logout'>
+                  <button onClick={onLogoutClick}>로그아웃</button>
+                </DropdownMenu.MenuItem>
+              </DropdownMenu.MenuContent>
+            </DropdownMenu>
           </Flex>
         ) : (
           <div className='relative h-9 w-24'>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       next:
         specifier: ^14.2.16
         version: 14.2.17(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1)
+      next-auth:
+        specifier: 5.0.0-beta.25
+        version: 5.0.0-beta.25(next@14.2.17)(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -454,6 +457,29 @@ packages:
       rc-util: 5.43.0(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@auth/core@0.37.2:
+    resolution: {integrity: sha512-kUvzyvkcd6h1vpeMAojK2y7+PAV5H+0Cc9+ZlKYDFhDY31AlvsB+GW5vNO4qE3Y07KeQgvNO9U0QUx/fN62kBw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      '@types/cookie': 0.6.0
+      cookie: 0.7.1
+      jose: 5.9.6
+      oauth4webapi: 3.1.4
+      preact: 10.11.3
+      preact-render-to-string: 5.2.3(preact@10.11.3)
     dev: false
 
   /@babel/code-frame@7.26.2:
@@ -2876,6 +2902,10 @@ packages:
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
+  /@panva/hkdf@1.2.1:
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -3826,7 +3856,6 @@ packages:
 
   /@types/cookie@0.6.0:
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-    dev: true
 
   /@types/cors@2.8.17:
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
@@ -5504,7 +5533,6 @@ packages:
   /cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -7989,6 +8017,10 @@ packages:
   /jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  /jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -8552,6 +8584,27 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /next-auth@5.0.0-beta.25(next@14.2.17)(react@18.3.1):
+    resolution: {integrity: sha512-2dJJw1sHQl2qxCrRk+KTQbeH+izFbGFPuJj5eGgBZFYyiYYtvlrBeUw1E/OJJxTRjuxbSYGnCTkUIRsIIW0bog==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0-0
+      nodemailer: ^6.6.5
+      react: ^18.2.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+    dependencies:
+      '@auth/core': 0.37.2
+      next: 14.2.17(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+    dev: false
+
   /next@14.2.17(@babel/core@7.26.0)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-hNo/Zy701DDO3nzKkPmsLRlDfNCtb1OJxFUvjGEl04u7SFa3zwC6hqsOUzMajcaEOEV8ey1GjvByvrg0Qr5AiQ==}
     engines: {node: '>=18.17.0'}
@@ -8672,6 +8725,10 @@ packages:
     dependencies:
       boolbase: 1.0.0
     dev: true
+
+  /oauth4webapi@3.1.4:
+    resolution: {integrity: sha512-eVfN3nZNbok2s/ROifO0UAc5G8nRoLSbrcKJ09OqmucgnhXEfdIQOR4gq1eJH1rN3gV7rNw62bDEgftsgFtBEg==}
+    dev: false
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -9211,6 +9268,19 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  /preact-render-to-string@5.2.3(preact@10.11.3):
+    resolution: {integrity: sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==}
+    peerDependencies:
+      preact: '>=10'
+    dependencies:
+      preact: 10.11.3
+      pretty-format: 3.8.0
+    dev: false
+
+  /preact@10.11.3:
+    resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
+    dev: false
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -9315,6 +9385,10 @@ packages:
       ansi-styles: 5.2.0
       react-is: 17.0.2
     dev: true
+
+  /pretty-format@3.8.0:
+    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
+    dev: false
 
   /prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}

--- a/turbo.json
+++ b/turbo.json
@@ -28,12 +28,12 @@
       "persistent": true
     },
     "web#dev": {
-      "env": ["ANI_*"],
-      "passThroughEnv": ["ANI_*"]
+      "env": ["AUTH_*"],
+      "passThroughEnv": ["AUTH_*"]
     },
     "web#build": {
-      "env": ["ANI_*"],
-      "passThroughEnv": ["ANI_*"]
+      "env": ["AUTH_*"],
+      "passThroughEnv": ["AUTH_*"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [".env"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -25,6 +26,14 @@
     "storybook": {
       "cache": false,
       "persistent": true
+    },
+    "web#dev": {
+      "env": ["ANI_*"],
+      "passThroughEnv": ["ANI_*"]
+    },
+    "web#build": {
+      "env": ["ANI_*"],
+      "passThroughEnv": ["ANI_*"]
     }
   }
 }


### PR DESCRIPTION
## 🌱 작업 개요

<!--작업하신 내용을 간단하게 목록 형식으로 설명해주세요.-->
- 로그인/회원가입 기능을 추가하였습니다.
- build를 통한 검사를 제거하였습니다.

## 🧐 중요한 변경 사항

### 로그인/회원가입 기능을 추가하였습니다.

현재 개발 환경을 올바르게 사용하기 위해서는 auth 서버내에 env 파일을 추가하여야 합니다.

```tsx
ANI_URL={본인 실행 주소} # ex) https://zero.dev
```

또한 클라이언트 환경에서 env도 추가하여야 합니다.

```text
NEXT_PUBLIC_AUTH_URL=http://localhost:8080
NEXT_PUBLIC_API_URL=http://localhost:9090
NEXT_PUBLIC_CLIENT_URL=로컬환경주소
NEXTAUTH_URL=로컬환경주소

AUTH_SECRET=''
```

`AUTH_SECRET`의 경우 `npx auth secret` 명령어로 만들 수 있는 해시 값입니다. [참고자료](https://authjs.dev/getting-started/installation)

소셜 로그인의 경우 next-auth에서 제공하는 provider를 사용하는 것이 아닌, 직접 서버로부터 호출하여 하는 프로세스로 진행하였습니다.

>서버에서 디스코드 화면 호출 -> 클라이언트 미들웨어 서버 리다이렉트 -> 서버에 콜백 함수로 전달 -> 토큰 발급 및 로그인 처리

서버 쪽과 합의를 해서 맞춰야 하는 부분이 있지만, 로그인, 회원가입 모달쪽 ui 작업전에 먼저 올려드립니다.

### 빌드 검사를 제거하였습니다.

빌드 검사의 경우 현재 실제 api를 연결하는 것이 아닌 로컬 api를 사용하여 연결중이기 때문에 빌드 에러가 날 수 밖에 없어 제거하였습니다.

<!--스크린샷이 있다면 추가해주세요.-->
<!--공용 컴포넌트, 린트 설정 등에 변경이 있다면 꼭 공유해주세요.-->
