### PR TITLE
feat: detail 페이지 타입 변경 및 api 연결

### DIFF
--- a/apps/web/app/api/v1/auth/social/discord/callback/route.ts
+++ b/apps/web/app/api/v1/auth/social/discord/callback/route.ts
@@ -12,9 +12,7 @@ export async function GET(request: Request) {
       return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL ?? '/error/404')
     }
 
-    const {
-      data: { accessToken, refreshToken }
-    } = await oauthLogin({ provider: 'discord', state, code })
+    const { refreshToken, accessToken } = await oauthLogin({ provider: 'discord', state, code })
 
     if (!accessToken || !refreshToken) {
       return NextResponse.redirect(process.env.NEXT_PUBLIC_CLIENT_URL ?? '/error/404')

--- a/apps/web/app/path/[pathId]/page.tsx
+++ b/apps/web/app/path/[pathId]/page.tsx
@@ -2,7 +2,6 @@ import { getPathIntroduce } from '@/views/path/api/get-path-introduce'
 import { PathIntroducePage } from '@/views/path/ui/IntroducePage'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { Suspense } from 'react'
 
 export async function generateMetadata({
   params
@@ -10,11 +9,9 @@ export async function generateMetadata({
   params: { pathId: string }
 }): Promise<Metadata> {
   const { pathId } = params
-  const pathName = pathId
-
   return {
     title: `ANI | 패스 소개`,
-    description: `${pathName} 패스에 대한 소개 페이지입니다.`
+    description: `${pathId} 패스에 대한 소개 페이지입니다.`
   }
 }
 
@@ -24,6 +21,8 @@ export default async function Page({ params: { pathId } }: { params: { pathId: s
   if (!data) {
     return notFound()
   }
+
+  console.log(data)
 
   return <PathIntroducePage data={data.data} />
 }

--- a/apps/web/app/path/[pathId]/page.tsx
+++ b/apps/web/app/path/[pathId]/page.tsx
@@ -22,7 +22,5 @@ export default async function Page({ params: { pathId } }: { params: { pathId: s
     return notFound()
   }
 
-  console.log(data)
-
   return <PathIntroducePage data={data.data} />
 }

--- a/apps/web/src/__mock__/data/path.ts
+++ b/apps/web/src/__mock__/data/path.ts
@@ -5,12 +5,13 @@ import { GetPathLoadResponseType } from '@/views/path/api/get-path-load'
 import { GetPathPageResponseType } from '@/views/path/api/get-path-page'
 import { GetPathStatusResponseType } from '@/views/path/api/get-path-status'
 import { ServerDrivenComponentType } from '@repo/sdu'
+import { PathStatus } from '@/shared/types/path'
 export const pathIntroduceMock = (
   pathId: number | string
 ): GetPathIntroduceResponseType['data'] => {
   return {
     isSubscribed: false,
-    status: 'PENDING_REVIEW',
+    status: 'PENDING',
     pathId,
     startDate: '2024-11-15T00:00:00.000Z',
     endDate: '2025-03-31T00:00:00.000Z',
@@ -36,222 +37,222 @@ export const pathIntroduceMock = (
             ]
           }
         }
-      ] as unknown as ServerDrivenComponentType[]
-    },
-    parts: [
-      {
-        id: 1,
-        title: 'HTML 개요(1)',
-        order: 1,
-        page: [
-          {
-            id: 1,
-            order: 1,
-            type: 'LEARNING_CONTENTS',
-            title: '첫 인사 및 강의 개요'
-          },
-          {
-            id: 2,
-            order: 2,
-            type: 'LEARNING_CONTENTS',
-            title: '기본 문법'
-          },
-          {
-            id: 3,
-            order: 3,
-            type: 'LEARNING_CONTENTS',
-            title: '부모와 자식 관계의 이해'
-          },
-          {
-            id: 4,
-            order: 4,
-            type: 'LEARNING_CONTENTS',
-            title: 'Doctype(DTD)'
-          },
-          {
-            id: 5,
-            order: 5,
-            type: 'LEARNING_CONTENTS',
-            title: 'HTML, HEAD, BODY'
-          },
-          {
-            id: 6,
-            order: 6,
-            type: 'LEARNING_CONTENTS',
-            title: '정보를 의미하는 태그 살펴보기'
-          },
-          {
-            id: 7,
-            order: 7,
-            type: 'VIDEO',
-            title: '화면에 이미지 출력하기',
-            videoLength: '15:30'
-          },
-          {
-            id: 8,
-            order: 8,
-            type: 'QUIZ',
-            title: '마무리 퀴즈'
-          }
-        ]
-      },
-      {
-        id: 2,
-        title: 'HTML 개요(2)',
-        order: 2,
-        page: [
-          {
-            id: 9,
-            order: '9',
-            type: 'LEARNING_CONTENTS',
-            title: '첫 인사 및 강의 개요'
-          },
-          {
-            id: 10,
-            order: '10',
-            type: 'LEARNING_CONTENTS',
-            title: '기본 문법'
-          },
-          {
-            id: 11,
-            order: '11',
-            type: 'LEARNING_CONTENTS',
-            title: '부모와 자식 관계의 이해'
-          },
-          {
-            id: 12,
-            order: 12,
-            type: 'LEARNING_CONTENTS',
-            title: 'Doctype(DTD)'
-          },
-          {
-            id: 13,
-            order: 13,
-            type: 'LEARNING_CONTENTS',
-            title: 'HTML, HEAD, BODY'
-          },
-          {
-            id: 14,
-            order: 14,
-            type: 'LEARNING_CONTENTS',
-            title: '정보를 의미하는 태그 살펴보기'
-          },
-          {
-            id: 15,
-            order: 15,
-            type: 'VIDEO',
-            title: '화면에 이미지 출력하기',
-            videoLength: '15:30'
-          }
-        ]
-      },
-      {
-        id: 2,
-        title: 'HTML 개요(2)',
-        order: 2,
-        page: [
-          {
-            id: 9,
-            order: '9',
-            type: 'LEARNING_CONTENTS',
-            title: '첫 인사 및 강의 개요'
-          },
-          {
-            id: 10,
-            order: '10',
-            type: 'LEARNING_CONTENTS',
-            title: '기본 문법'
-          },
-          {
-            id: 11,
-            order: '11',
-            type: 'LEARNING_CONTENTS',
-            title: '부모와 자식 관계의 이해'
-          },
-          {
-            id: 12,
-            order: 12,
-            type: 'LEARNING_CONTENTS',
-            title: 'Doctype(DTD)'
-          },
-          {
-            id: 13,
-            order: 13,
-            type: 'LEARNING_CONTENTS',
-            title: 'HTML, HEAD, BODY'
-          },
-          {
-            id: 14,
-            order: 14,
-            type: 'LEARNING_CONTENTS',
-            title: '정보를 의미하는 태그 살펴보기'
-          },
-          {
-            id: 15,
-            order: 15,
-            type: 'VIDEO',
-            title: '화면에 이미지 출력하기',
-            videoLength: '15:30'
-          }
-        ]
-      },
-      {
-        id: 2,
-        title: 'HTML 개요(2)',
-        order: 2,
-        page: [
-          {
-            id: 9,
-            order: '9',
-            type: 'LEARNING_CONTENTS',
-            title: '첫 인사 및 강의 개요'
-          },
-          {
-            id: 10,
-            order: '10',
-            type: 'LEARNING_CONTENTS',
-            title: '기본 문법'
-          },
-          {
-            id: 11,
-            order: '11',
-            type: 'LEARNING_CONTENTS',
-            title: '부모와 자식 관계의 이해'
-          },
-          {
-            id: 12,
-            order: 12,
-            type: 'LEARNING_CONTENTS',
-            title: 'Doctype(DTD)'
-          },
-          {
-            id: 13,
-            order: 13,
-            type: 'LEARNING_CONTENTS',
-            title: 'HTML, HEAD, BODY'
-          },
-          {
-            id: 14,
-            order: 14,
-            type: 'LEARNING_CONTENTS',
-            title: '정보를 의미하는 태그 살펴보기'
-          },
-          {
-            id: 15,
-            order: 15,
-            type: 'VIDEO',
-            title: '화면에 이미지 출력하기',
-            videoLength: '15:30'
-          }
-        ]
-      }
-    ]
+      ] as unknown as ServerDrivenComponentType[],
+      parts: [
+        {
+          id: 1,
+          title: 'HTML 개요(1)',
+          order: 1,
+          page: [
+            {
+              id: 1,
+              order: 1,
+              type: 'LEARNING_CONTENTS',
+              title: '첫 인사 및 강의 개요'
+            },
+            {
+              id: 2,
+              order: 2,
+              type: 'LEARNING_CONTENTS',
+              title: '기본 문법'
+            },
+            {
+              id: 3,
+              order: 3,
+              type: 'LEARNING_CONTENTS',
+              title: '부모와 자식 관계의 이해'
+            },
+            {
+              id: 4,
+              order: 4,
+              type: 'LEARNING_CONTENTS',
+              title: 'Doctype(DTD)'
+            },
+            {
+              id: 5,
+              order: 5,
+              type: 'LEARNING_CONTENTS',
+              title: 'HTML, HEAD, BODY'
+            },
+            {
+              id: 6,
+              order: 6,
+              type: 'LEARNING_CONTENTS',
+              title: '정보를 의미하는 태그 살펴보기'
+            },
+            {
+              id: 7,
+              order: 7,
+              type: 'VIDEO',
+              title: '화면에 이미지 출력하기',
+              videoLength: '15:30'
+            },
+            {
+              id: 8,
+              order: 8,
+              type: 'QUIZ',
+              title: '마무리 퀴즈'
+            }
+          ]
+        },
+        {
+          id: 2,
+          title: 'HTML 개요(2)',
+          order: 2,
+          page: [
+            {
+              id: 9,
+              order: '9',
+              type: 'LEARNING_CONTENTS',
+              title: '첫 인사 및 강의 개요'
+            },
+            {
+              id: 10,
+              order: '10',
+              type: 'LEARNING_CONTENTS',
+              title: '기본 문법'
+            },
+            {
+              id: 11,
+              order: '11',
+              type: 'LEARNING_CONTENTS',
+              title: '부모와 자식 관계의 이해'
+            },
+            {
+              id: 12,
+              order: 12,
+              type: 'LEARNING_CONTENTS',
+              title: 'Doctype(DTD)'
+            },
+            {
+              id: 13,
+              order: 13,
+              type: 'LEARNING_CONTENTS',
+              title: 'HTML, HEAD, BODY'
+            },
+            {
+              id: 14,
+              order: 14,
+              type: 'LEARNING_CONTENTS',
+              title: '정보를 의미하는 태그 살펴보기'
+            },
+            {
+              id: 15,
+              order: 15,
+              type: 'VIDEO',
+              title: '화면에 이미지 출력하기',
+              videoLength: '15:30'
+            }
+          ]
+        },
+        {
+          id: 2,
+          title: 'HTML 개요(2)',
+          order: 2,
+          page: [
+            {
+              id: 9,
+              order: '9',
+              type: 'LEARNING_CONTENTS',
+              title: '첫 인사 및 강의 개요'
+            },
+            {
+              id: 10,
+              order: '10',
+              type: 'LEARNING_CONTENTS',
+              title: '기본 문법'
+            },
+            {
+              id: 11,
+              order: '11',
+              type: 'LEARNING_CONTENTS',
+              title: '부모와 자식 관계의 이해'
+            },
+            {
+              id: 12,
+              order: 12,
+              type: 'LEARNING_CONTENTS',
+              title: 'Doctype(DTD)'
+            },
+            {
+              id: 13,
+              order: 13,
+              type: 'LEARNING_CONTENTS',
+              title: 'HTML, HEAD, BODY'
+            },
+            {
+              id: 14,
+              order: 14,
+              type: 'LEARNING_CONTENTS',
+              title: '정보를 의미하는 태그 살펴보기'
+            },
+            {
+              id: 15,
+              order: 15,
+              type: 'VIDEO',
+              title: '화면에 이미지 출력하기',
+              videoLength: '15:30'
+            }
+          ]
+        },
+        {
+          id: 2,
+          title: 'HTML 개요(2)',
+          order: 2,
+          page: [
+            {
+              id: 9,
+              order: '9',
+              type: 'LEARNING_CONTENTS',
+              title: '첫 인사 및 강의 개요'
+            },
+            {
+              id: 10,
+              order: '10',
+              type: 'LEARNING_CONTENTS',
+              title: '기본 문법'
+            },
+            {
+              id: 11,
+              order: '11',
+              type: 'LEARNING_CONTENTS',
+              title: '부모와 자식 관계의 이해'
+            },
+            {
+              id: 12,
+              order: 12,
+              type: 'LEARNING_CONTENTS',
+              title: 'Doctype(DTD)'
+            },
+            {
+              id: 13,
+              order: 13,
+              type: 'LEARNING_CONTENTS',
+              title: 'HTML, HEAD, BODY'
+            },
+            {
+              id: 14,
+              order: 14,
+              type: 'LEARNING_CONTENTS',
+              title: '정보를 의미하는 태그 살펴보기'
+            },
+            {
+              id: 15,
+              order: 15,
+              type: 'VIDEO',
+              title: '화면에 이미지 출력하기',
+              videoLength: '15:30'
+            }
+          ]
+        }
+      ]
+    }
   }
 }
 
 export const pathSidebarStatusMock = (
   pathId: number | string,
-  status?: 'IN_PROGRESS' | 'PENDING_REVIEW' | 'COMPLETED'
+  status?: PathStatus
 ): GetPathStatusResponseType['data'] => {
   return {
     path: {
@@ -261,7 +262,7 @@ export const pathSidebarStatusMock = (
       startDate: '2024-11-15T00:00:00.000Z',
       endDate: '2025-03-31T00:00:00.000Z',
       progress: 100,
-      status: status ? status : 'PENDING_REVIEW',
+      status: status ? status : 'PENDING',
       mentors: [
         {
           nickname: '김멘토',

--- a/apps/web/src/features/auth/api/oauth-login.ts
+++ b/apps/web/src/features/auth/api/oauth-login.ts
@@ -1,4 +1,7 @@
-import type { AuthResponse } from '@/__mock__/types/auth'
+type OauthLoginResponse = {
+  accessToken: string
+  refreshToken: string
+}
 
 export async function oauthLogin({
   provider,
@@ -10,23 +13,20 @@ export async function oauthLogin({
   code: string
 }) {
   const baseUrl = `${process.env.NEXT_PUBLIC_AUTH_URL}/api/v1/auth/social/${provider}/callback`
-  const parmas = [`state=${state}`, `code=${code}`].join('&')
+  const params = [`state=${state}`, `code=${code}`].join('&')
 
-  const response = await fetch(`${baseUrl}?${parmas}`, {
+  const response = await fetch(`${baseUrl}?${params}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json'
     }
   })
 
-  console.log('response', response)
-
   if (!response.ok) {
-    console.log('에러 발생')
+
     const error = await response.json()
     throw new Error(error.message)
   }
 
-  const data = await response.json()
-  return data
+  return await response.json() as OauthLoginResponse
 }

--- a/apps/web/src/shared/types/path.ts
+++ b/apps/web/src/shared/types/path.ts
@@ -1,4 +1,4 @@
-export type PathStatus = 'PENDING_REVIEW' | 'IN_PROGRESS' | 'COMPLETED'
+export type PathStatus = 'PENDING' | 'APPLICATION_PERIOD' | 'IN_PROGRESS' | 'COMPLETED'
 export type PageFeature = 'LEARNING_CONTENTS' | 'QUIZ' | 'VIDEO'
 
 export interface BasePathType {

--- a/apps/web/src/shared/ui/header/index.tsx
+++ b/apps/web/src/shared/ui/header/index.tsx
@@ -37,7 +37,7 @@ export function HeaderInner({ isLoggedIn }: Props) {
         {isLoggedIn ? (
           <Flex
             align={'center'}
-            gap={8}>
+            gap={32}>
             <button
               onClick={onAlarmClick}
               className='h-9 w-9'

--- a/apps/web/src/views/path/api/get-path-introduce.ts
+++ b/apps/web/src/views/path/api/get-path-introduce.ts
@@ -1,5 +1,4 @@
 import { HTTP_HEADERS, HTTP_METHODS } from '@/shared/config/constants/http'
-import type { BasePartType } from '@/shared/types/path'
 import type { PathDetailType, PathIntroduceType } from '../model/apis'
 
 type Data = {

--- a/apps/web/src/views/path/api/get-path-introduce.ts
+++ b/apps/web/src/views/path/api/get-path-introduce.ts
@@ -4,7 +4,6 @@ import type { PathDetailType, PathIntroduceType } from '../model/apis'
 
 type Data = {
   path: PathDetailType
-  parts: BasePartType[]
 } & PathIntroduceType
 
 export type GetPathIntroduceParamsType = {
@@ -24,7 +23,7 @@ export type GetPathIntroduceResponseType = {
 export async function getPathIntroduce({
   pathId
 }: GetPathIntroduceParamsType): Promise<GetPathIntroduceResponseType> {
-  const response = await fetch(process.env.NEXT_PUBLIC_API_URL + `/path/${pathId}`, {
+  const response = await fetch(process.env.NEXT_PUBLIC_API_URL + `/api/v1/path?id=${pathId}`, {
     method: HTTP_METHODS.GET,
     headers: HTTP_HEADERS.JSON,
     cache: 'no-store'

--- a/apps/web/src/views/path/model/apis.ts
+++ b/apps/web/src/views/path/model/apis.ts
@@ -1,4 +1,4 @@
-import { PathStatus } from '@/shared/types/path'
+import { BasePartType, PathStatus } from '@/shared/types/path'
 import { ServerDrivenComponentType } from '@repo/sdu'
 
 // 패스 소개 데이터 타입
@@ -8,11 +8,11 @@ export type PathIntroduceType = {
   pathId: number | string
   startDate: string | Date
   endDate: string | Date
-  level: string
-  maxStudent: number
-  recruitStartDate: string | Date
-  recruitEndDate: string | Date
-  announcementDate: string | Date
+  level: string | null
+  maxStudent: number | null
+  recruitStartDate: string | Date | null
+  recruitEndDate: string | Date | null
+  announcementDate: string | Date | null
 }
 
 // 패스 상세 데이터 타입
@@ -21,4 +21,5 @@ export type PathDetailType = {
   description: string
   thumbnail: string
   content: ServerDrivenComponentType[]
+  parts: BasePartType[]
 }

--- a/apps/web/src/views/path/ui/IntroducePage/index.tsx
+++ b/apps/web/src/views/path/ui/IntroducePage/index.tsx
@@ -16,15 +16,20 @@ type Props = {
 }
 
 export function PathIntroducePage({ data }: Props) {
+  const hasRecruitStartOrEndDate = data.recruitStartDate && data.recruitEndDate
+  const hasAnnouncementDate = data.announcementDate
+  const hasLevel = data.level
+
   return (
     <FullScreenLayout>
       {/* 패스 타이틀 바 */}
       <PathIntroduceTobBanner
-        thumbnail={data.path.thumbnail}
+        thumbnail={data.path.thumbnail || '/avif/placeholder.avif'}
         title={data.path.title}
         description={data.path.description}
         isSubscribed={data.isSubscribed}
         pathId={data.pathId}
+        status={data.status}
       />
 
       {/* 패스 상세 정보 */}
@@ -41,18 +46,22 @@ export function PathIntroducePage({ data }: Props) {
           <Flex
             direction={'column'}
             gap={8}>
-            <Typography
-              variant='body-1-normal'
-              fontWeight={'medium'}
-              color='alternative'>
-              신청 기한
-            </Typography>
-            <Typography
-              variant='body-1-normal'
-              fontWeight={'medium'}
-              color='alternative'>
-              발표일
-            </Typography>
+            {hasRecruitStartOrEndDate && (
+              <Typography
+                variant='body-1-normal'
+                fontWeight={'medium'}
+                color='alternative'>
+                신청 기한
+              </Typography>
+            )}
+            {hasAnnouncementDate && (
+              <Typography
+                variant='body-1-normal'
+                fontWeight={'medium'}
+                color='alternative'>
+                발표일
+              </Typography>
+            )}
             <Typography
               variant='body-1-normal'
               fontWeight={'medium'}
@@ -65,27 +74,33 @@ export function PathIntroducePage({ data }: Props) {
               color='alternative'>
               모집인원
             </Typography>
-            <Typography
-              variant='body-1-normal'
-              fontWeight={'medium'}
-              color='alternative'>
-              난이도
-            </Typography>
+            {hasLevel && (
+              <Typography
+                variant='body-1-normal'
+                fontWeight={'medium'}
+                color='alternative'>
+                난이도
+              </Typography>
+            )}
           </Flex>
           <Flex
             direction={'column'}
             gap={8}>
-            <Typography
-              variant='body-1-normal'
-              fontWeight={'medium'}>
-              {formatDate(data.recruitStartDate, 'yyyy.MM.dd')} -{' '}
-              {formatDate(data.recruitEndDate, 'yyyy.MM.dd')}
-            </Typography>
-            <Typography
-              variant='body-1-normal'
-              fontWeight={'medium'}>
-              {formatDate(data.announcementDate, 'yyyy.MM.dd')}
-            </Typography>
+            {hasRecruitStartOrEndDate && (
+              <Typography
+                variant='body-1-normal'
+                fontWeight={'medium'}>
+                {formatDate(data.recruitStartDate, 'yyyy.MM.dd')} -{' '}
+                {formatDate(data.recruitEndDate, 'yyyy.MM.dd')}
+              </Typography>
+            )}
+            {hasAnnouncementDate && (
+              <Typography
+                variant='body-1-normal'
+                fontWeight={'medium'}>
+                {formatDate(data.announcementDate, 'yyyy.MM.dd')}
+              </Typography>
+            )}
             <Typography
               variant='body-1-normal'
               fontWeight={'medium'}>
@@ -94,13 +109,15 @@ export function PathIntroducePage({ data }: Props) {
             <Typography
               variant='body-1-normal'
               fontWeight={'medium'}>
-              {data.maxStudent}명
+              {data.maxStudent ?? 0}명
             </Typography>
-            <Typography
-              variant='body-1-normal'
-              fontWeight={'medium'}>
-              {data.level}
-            </Typography>
+            {hasLevel && (
+              <Typography
+                variant='body-1-normal'
+                fontWeight={'medium'}>
+                {data.level}
+              </Typography>
+            )}
           </Flex>
         </Flex>
         <Flex
@@ -148,8 +165,8 @@ export function PathIntroducePage({ data }: Props) {
           커리큘럼을 보여드려요
         </Typography>
         <Flex className='gap-[1.5rem]'>
-          <IntroduceCurriculumBar parts={data.parts} />
-          <IntroduceCurriculumContent parts={data.parts} />
+          <IntroduceCurriculumBar parts={data.path.parts} />
+          <IntroduceCurriculumContent parts={data.path.parts} />
         </Flex>
       </section>
     </FullScreenLayout>

--- a/apps/web/src/widgets/path/ui/introduce/CurriculumBar.tsx
+++ b/apps/web/src/widgets/path/ui/introduce/CurriculumBar.tsx
@@ -38,6 +38,7 @@ function PathLines({ content, isLastContent }: PathLinesProps) {
 }
 
 function IntroduceCurriculumBar({ parts }: Props) {
+  console.log('parts', parts)
   return (
     <Flex
       align='start'

--- a/apps/web/src/widgets/path/ui/introduce/CurriculumBar.tsx
+++ b/apps/web/src/widgets/path/ui/introduce/CurriculumBar.tsx
@@ -38,7 +38,6 @@ function PathLines({ content, isLastContent }: PathLinesProps) {
 }
 
 function IntroduceCurriculumBar({ parts }: Props) {
-  console.log('parts', parts)
   return (
     <Flex
       align='start'

--- a/apps/web/src/widgets/path/ui/introduce/CurriculumContent.tsx
+++ b/apps/web/src/widgets/path/ui/introduce/CurriculumContent.tsx
@@ -63,7 +63,9 @@ function IntroduceCurriculumContent({ parts }: Props) {
       gap={24}
       direction={'column'}>
       {parts.map((part, index) => (
-        <Flex direction={'column'}>
+        <Flex
+          key={index}
+          direction={'column'}>
           <Typography
             variant='heading-2'
             color='alternative'>

--- a/apps/web/src/widgets/path/ui/introduce/TopBanner.tsx
+++ b/apps/web/src/widgets/path/ui/introduce/TopBanner.tsx
@@ -2,6 +2,7 @@ import PathApplyButton from '@/features/path/ui/ApplyButton'
 import PathCancleButton from '@/features/path/ui/CancleButton'
 import PathInterruptionButton from '@/features/path/ui/InterruptionButton'
 import { Flex, ImageSection, Typography } from '@repo/ui/server'
+import { PathStatus } from '@/shared/types/path'
 
 type Props = {
   thumbnail: string
@@ -9,9 +10,17 @@ type Props = {
   description: string
   isSubscribed: boolean
   pathId: number | string
+  status: PathStatus
 }
 
-function PathIntroduceTopBanner({ thumbnail, title, description, isSubscribed, pathId }: Props) {
+function PathIntroduceTopBanner({
+  status,
+  thumbnail,
+  title,
+  description,
+  isSubscribed,
+  pathId
+}: Props) {
   return (
     <section
       id='path_title_banner'
@@ -39,7 +48,7 @@ function PathIntroduceTopBanner({ thumbnail, title, description, isSubscribed, p
                   {title}
                 </Typography>
               </div>
-              <PathInterruptionButton pathId={pathId} />
+              {isSubscribed && status === 'PENDING' && <PathInterruptionButton pathId={pathId} />}
             </Flex>
             <Typography
               className='w-[30rem] whitespace-pre-line'


### PR DESCRIPTION
## 🌱 작업 개요

<!--작업하신 내용을 간단하게 목록 형식으로 설명해주세요.-->

- 불필요한 구문 수정
- 헤더 간격 변경
- detail page api 연결 완료
- 타입 추가

## 👻 질문 사항

next-auth를 사용하여 진행하고자 하였는데, auth.js의 Provider가 아닌 애시 당초에 커스텀 하여 진행하다 보니 진행하는 방식이 interceptor를 만들어 진행하면 더 좋을 것 같아 해당 방법으로 변경해 봅니다.

<!--함께 고민하고 싶은 것이 있다면 작성해주세요.-->
<!--중점적으로 피드백 받고 싶은 부분을 작성해주세요.-->
